### PR TITLE
Fix is_true for bytes

### DIFF
--- a/envex/env_wrapper.py
+++ b/envex/env_wrapper.py
@@ -20,7 +20,7 @@ class Env:
     _exception: Type[Exception]
 
     _BOOLEAN_TRUE_STRINGS = ("T", "t", "1", "on", "ok", "Y", "y", "en")
-    _BOOLEAN_TRUE_BYTES = (s.encode("utf-8") for s in _BOOLEAN_TRUE_STRINGS)
+    _BOOLEAN_TRUE_BYTES = (b"T", b"t", b"1", b"on", b"ok", b"Y", b"y", b"en")
     _EXCEPTION_CLS = KeyError
 
     def __init__(


### PR DESCRIPTION
<!-- Generated by sourcery-ai[bot]: start summary -->

## Summary by Sourcery

This pull request fixes an issue with the `is_true` method in the `Env` class, ensuring that byte strings are correctly recognized as true values by explicitly defining `_BOOLEAN_TRUE_BYTES` as a tuple of byte literals.

* **Bug Fixes**:
    - Fixed the `is_true` method to correctly handle byte strings by explicitly defining `_BOOLEAN_TRUE_BYTES` as a tuple of byte literals.

<!-- Generated by sourcery-ai[bot]: end summary -->