### PR TITLE
 bump version to 3.3.1 and fix release workflow

### DIFF
--- a/.github/workflows/python-release-publish.yml
+++ b/.github/workflows/python-release-publish.yml
@@ -13,7 +13,6 @@ jobs:
     strategy:
       matrix:
         python-version: ["3.13", "3.12", "3.11", "3.10"]
-        poetry-version: ["1.8.4"]
 
     steps:
       - name: checkout
@@ -28,11 +27,7 @@ jobs:
           python-version: ${{ matrix.python-version }}
           sync-args: --group vault
 
-      - name: Configure pypi
-        shell: bash
-        run: uv config pypi-token.pypi ${{ secrets.PYPI_TOKEN }}
-
       - name: build and publish package
         if: matrix.python-version == env.TARGET_PYTHON_VERSION
         shell: bash
-        run: uv publish --build
+        run: uv publish --build --token ${{ secrets.PYPI_TOKEN }}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "envex"
-version = "3.3.0"
+version = "3.3.1"
 description = "Environment interface with .env and hashicorp vault support"
 readme = "README.md"
 license = { file = "LICENSE.md" }


### PR DESCRIPTION
• Update version in pyproject.toml from 3.3.0 to 3.3.1
 • Remove poetry-version from matrix in release workflow
 • Pass PYPI_TOKEN directly to uv publish command

## Summary by Sourcery

Bump the project version to 3.3.1 and update the release workflow by removing the poetry-version from the matrix and passing the PYPI_TOKEN directly to the uv publish command.

Build:
- Update version in pyproject.toml from 3.3.0 to 3.3.1.

CI:
- Remove poetry-version from matrix in release workflow.
- Pass PYPI_TOKEN directly to uv publish command in the release workflow.