### PR TITLE
Prepare release 4.3.0

### DIFF
--- a/.github/workflows/python-release-publish.yml
+++ b/.github/workflows/python-release-publish.yml
@@ -9,6 +9,7 @@ env:
 
 jobs:
   checks:
+    if: startsWith(github.ref, 'refs/tags/v')
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -19,7 +20,7 @@ jobs:
         uses: actions/checkout@v6
         with:
           fetch-depth: 0
-          ref: ${{ github.ref }}
+          ref: ${{ github.event.release.tag_name }}
 
       - name: Test and Build
         uses: ./.github/actions/test-and-build

--- a/.github/workflows/python-release-publish.yml
+++ b/.github/workflows/python-release-publish.yml
@@ -19,7 +19,7 @@ jobs:
         uses: actions/checkout@v6
         with:
           fetch-depth: 0
-          ref: main
+          ref: ${{ github.ref }}
 
       - name: Test and Build
         uses: ./.github/actions/test-and-build

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # ChangeLog
 
+### v4.3.0
+
+- Maintenance release only.
+- Dependency and tooling upgrades.
+- Phase out Python 3.11 support and add Python 3.14 support.
+
 ### v4.2.0
 
 - Feature: Enhanced shell-like variable substitution in .env files

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "envex"
-version = "4.2.1"
+version = "4.3.0"
 description = "Environment interface with (optionally encrypted) .env with hashicorp vault support"
 readme = "README.md"
 license = { file = "LICENSE.md" }

--- a/uv.lock
+++ b/uv.lock
@@ -193,7 +193,7 @@ wheels = [
 
 [[package]]
 name = "envex"
-version = "4.2.1"
+version = "4.3.0"
 source = { editable = "." }
 dependencies = [
     { name = "pycryptodome" },


### PR DESCRIPTION
## Summary
- Bump package version to 4.3.0.
- Add the 4.3.0 changelog entry for the maintenance release.
- Update the publish workflow to build from the release ref instead of main.

## Summary by Sourcery

Prepare the 4.3.0 maintenance release and adjust the Python package publish workflow.

Enhancements:
- Update project version metadata to 4.3.0.
- Document 4.3.0 as a maintenance release with dependency/tooling updates and Python version support changes.

CI:
- Modify the release publish workflow to build artifacts from the release ref rather than the main branch.

Documentation:
- Add a changelog entry for version 4.3.0 describing the maintenance updates and Python version support changes.