### PR TITLE
Update README Python support

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ An `Env` instance delivers a lot of functionality by providing a type-smart fron
 pip install envex
 ```
 
-`envex` expects Python 3.11 or later; 3.7 through 3.10 should also work but haven't been tested.
+`envex` supports Python 3.12 through 3.14.
 
 ## Features
 


### PR DESCRIPTION
## Summary
- Update the README support note to Python 3.12 through 3.14.

## Summary by Sourcery

Documentation:
- Clarify that envex supports Python versions 3.12 through 3.14 in the README.