### PR TITLE
Fix workflow security scanning issues

### DIFF
--- a/.github/workflows/python-release-publish.yml
+++ b/.github/workflows/python-release-publish.yml
@@ -7,6 +7,9 @@ on:
 env:
   TARGET_PYTHON_VERSION: "3.12"
 
+permissions:
+  contents: read
+
 jobs:
   checks:
     if: startsWith(github.ref, 'refs/tags/v')

--- a/.github/workflows/python-test-and-build.yml
+++ b/.github/workflows/python-test-and-build.yml
@@ -20,7 +20,6 @@ jobs:
         uses: actions/checkout@v6
         with:
           fetch-depth: 0
-          ref: ${{ github.head_ref }}
 
       - name: Test and Build
         uses: ./.github/actions/test-and-build

--- a/envex/scripts/envsecrets.py
+++ b/envex/scripts/envsecrets.py
@@ -166,13 +166,6 @@ def create_or_update_secrets(secrets, key, cert, verbose):
     certpath = Path(cert).resolve().as_posix() if cert else None
     sm = secrets_manager(verify=certpath)
     sm.set_secrets(key, values=secrets)
-    if verbose:
-        import json
-
-        data = sm.get_secrets(key) or secrets
-        print(f"{sm.base_path}/{key}:")
-        for s in json.dumps(data, indent=4).splitlines():
-            print(f"    {s}")
 
 
 def main(args):

--- a/envex/scripts/envsecrets.py
+++ b/envex/scripts/envsecrets.py
@@ -166,6 +166,12 @@ def create_or_update_secrets(secrets, key, cert, verbose):
     certpath = Path(cert).resolve().as_posix() if cert else None
     sm = secrets_manager(verify=certpath)
     sm.set_secrets(key, values=secrets)
+    if verbose:
+        print(
+            f"{len(secrets)} secret{'' if len(secrets) == 1 else 's'} updated at "
+            f"{sm.base_path}/{key}",
+            file=sys.stderr,
+        )
 
 
 def main(args):


### PR DESCRIPTION
Overview
- Resolves the open workflow security scanning alert for pull request checkout behavior.
- Tightens workflow token permissions so CI and release jobs run with only the access they need.
- Removes verbose secret update output that could expose sensitive values during CLI use.

Changes
- CI now uses GitHub's default pull request checkout behavior instead of explicitly checking out the PR source branch.
- Release publishing declares read-only repository content permissions.
- Secret updates no longer print stored secret data when verbose mode is enabled.

Impact of the change
- Pull request validation continues to run against proposed changes while avoiding the CodeQL untrusted checkout pattern.
- Workflow token access is more constrained by default.
- Secret update operations avoid unnecessary disclosure in command output.

Notes
- The CodeQL alert should close after GitHub scans the updated workflow on the default branch.

## Summary by Sourcery

Tighten workflow security by constraining token permissions, avoiding untrusted PR checkout patterns, and reducing secret output verbosity.

Bug Fixes:
- Stop using an explicit PR source ref in CI checkout to eliminate the untrusted CodeQL checkout pattern.

Enhancements:
- Constrain the release publishing workflow to read-only repository contents permissions.
- Remove verbose secret update output that printed stored secret data.