### PR TITLE
Add authenticated environment file encryption

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,10 +2,13 @@
 
 ### v5.0.0
 
-- :warning: BREAKING CHANGE: encrypted files created by envex now use authenticated AES-256-GCM instead of the legacy AES-CBC format.
+- ⚠️ BREAKING CHANGE ⚠️: encrypted files created by envex now use authenticated AES-256-GCM instead of the legacy AES-CBC format.
 - Files encrypted with envex 5.0.0 or later cannot be decrypted by envex 4.x or older. Envex 5.0.0 can still decrypt legacy AES-CBC files so they can be migrated.
+- Legacy AES-CBC decryption now requires explicit legacy mode during migration; normal decryption rejects legacy headers to prevent downgrade from authenticated AES-GCM into the unauthenticated legacy path.
 - The encryption format changed because the previous AES-CBC format did not authenticate ciphertext and could be vulnerable to padding-oracle style attacks if decryption errors were exposed.
-- To migrate existing files, decrypt the legacy `.env.enc` file with a version that can read it, then re-encrypt it with envex 5.0.0 or later using `envcrypt --decrypt ...` followed by `envcrypt --encrypt ...`.
+- To migrate existing files, decrypt the legacy `.env.enc` file with a version that can read it, then re-encrypt it with envex 5.0.0 or later using
+  - `envcrypt --decrypt --legacy ...`, followed by
+  - `envcrypt --encrypt ...`.
 
 ### v4.4.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # ChangeLog
 
+### v5.0.0
+
+- :warning: BREAKING CHANGE: encrypted files created by envex now use authenticated AES-256-GCM instead of the legacy AES-CBC format.
+- Files encrypted with envex 5.0.0 or later cannot be decrypted by envex 4.x or older. Envex 5.0.0 can still decrypt legacy AES-CBC files so they can be migrated.
+- The encryption format changed because the previous AES-CBC format did not authenticate ciphertext and could be vulnerable to padding-oracle style attacks if decryption errors were exposed.
+- To migrate existing files, decrypt the legacy `.env.enc` file with a version that can read it, then re-encrypt it with envex 5.0.0 or later using `envcrypt --decrypt ...` followed by `envcrypt --encrypt ...`.
+
 ### v4.4.0
 
 - Bugfix: `Env.is_set()` now checks the effective source chain, including Vault/secret-manager-backed values.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,7 +40,7 @@
 - Bugfix: dicts passed in *args the Env() are now correctly converted to str->str mappings.
 - Feature: Env can now take BytesIO and StringIO objects in Env(*args). Since these are immediate objects, they are handled as priority variables, different to variables set via `.env` files in that they overwrite existing variables by default. Explicitly using the overwrite=False changes this behaviour.
 - Warning: To provide support for different types of streams, environment files are now handled internally as bytes. However, before evaluation they are converted via an encoding parameter that defaults to "utf-8".
-- Feature: Encrypted `.env` files (`.env.enc`) are now supported. You no longer need to implement a Hashicorp Vault in order to avoid having plain text secrets on the filesystem, you can simply encrypt the `.env` file directly. Use the `decrypt=True` parameter and provide the encryption pass phrase used to derive the key:
+- Feature: Encrypted `.env` files (`.env.enc`) are now supported. You no longer need to implement a Hashicorp Vault in order to avoid having plain text secrets on the filesystem, you can simply encrypt the `.env` file directly. Use the `decrypt=True` parameter and provide the encryption passphrase used to derive the key:
 
   - `password=<pass-phrase>`
   - `password=$<environment_variable_name>`

--- a/README.md
+++ b/README.md
@@ -161,13 +161,14 @@ If the feature is enabled and a pass phrase is provided when the environment fil
 This is a breaking encrypted-file format change:
 
 - Files encrypted by envex 5.0.0 and later cannot be decrypted by envex 4.x or older.
-- Envex 5.0.0 can still decrypt legacy AES-CBC files so existing files can be migrated.
+- Envex 5.0.0 can still decrypt legacy AES-CBC files with explicit legacy mode so existing files can be migrated.
 - Any file re-encrypted with envex 5.0.0 will require envex 5.0.0 or later to decrypt.
+- Normal decryption rejects legacy AES-CBC files by default so a modified AES-GCM file cannot be downgraded into the unauthenticated legacy path.
 
 To migrate an existing encrypted file, decrypt it with a version that can read the current file, then re-encrypt it with envex 5.0.0 or later:
 
 ```shell
-envcrypt --decrypt --password "$PASSPHRASE" .env.enc .env
+envcrypt --decrypt --legacy --password "$PASSPHRASE" .env.enc .env
 envcrypt --encrypt --password "$PASSPHRASE" .env .env.enc
 ```
 
@@ -181,7 +182,7 @@ rm .env .env.verify
 
 The `envcrypt` CLI utility supports the encryption and decryption of environment files.
 ```shell
-usage: envcrypt.py [-h] [-P PASSWORD | -E ENVIRON | -F FILE] [-e | -d] [-r] [-v] input [output]
+usage: envcrypt.py [-h] [-P PASSWORD | -E ENVIRON | -F FILE] [-e | -d] [--legacy] [-r] [-v] input [output]
 
 envcrypt: File encrypt/decrypt (authenticated AES-256-GCM)
 
@@ -198,6 +199,7 @@ options:
 
 -e, --encrypt            Use given password (default: False)
 -d, --decrypt            Read password from provided environment variable (default: False)
+--legacy                 Allow decrypting legacy AES-CBC files for migration (default: False)
 
 -r, --rm                 Remove input file after successful conversion (default: False)
 -v, --verbose            Increase output verbosity (default: False)

--- a/README.md
+++ b/README.md
@@ -148,7 +148,7 @@ This is enforced by the underlying os.environ, but also true of any provided env
 
 ## Encrypted Environment Files
 
-To enhance security of environment files that exist on the filesystem `envex` supports the creation and use of AES-256 encrypted files.
+To enhance security of environment files that exist on the filesystem `envex` supports the creation and use of authenticated AES-256-GCM encrypted files.
 
 Encrypted `.env` files are named as `.env.enc` by default (strictly, `${DOTENV:-.env}.enc`), to distinguish them from the unencrypted version, but this is only by convention; both to distinguish the files visually, and to prevent other dot-env readers from using them.
 
@@ -158,7 +158,7 @@ The `envcrypt` CLI utility supports the encryption and decryption of environment
 ```shell
 usage: envcrypt.py [-h] [-P PASSWORD | -E ENVIRON | -F FILE] [-e | -d] [-r] [-v] input [output]
 
-envcrypt: File encrypt/decrypt (AES-256-CBC with HMAC-SHA256)
+envcrypt: File encrypt/decrypt (authenticated AES-256-GCM)
 
 positional arguments:
 input                    File to encrypt or decrypt

--- a/README.md
+++ b/README.md
@@ -154,7 +154,7 @@ The new format authenticates encrypted data before returning plaintext and is no
 
 Encrypted `.env` files are named as `.env.enc` by default (strictly, `${DOTENV:-.env}.enc`), to distinguish them from the unencrypted version, but this is only by convention; both to distinguish the files visually, and to prevent other dot-env readers from using them.
 
-If the feature is enabled and a pass phrase is provided when the environment file is read, `envex` determines automatically if it contains encrypted data. If the `.enc` version of the environment file does not exist, the .env file - encrypted or not - is used as a fallback, but will otherwise be ignored.
+If the feature is enabled and a passphrase is provided when the environment file is read, `envex` determines automatically if it contains encrypted data. If the `.enc` version of the environment file does not exist, the .env file - encrypted or not - is used as a fallback, but will otherwise be ignored.
 
 ### Version 5 Encrypted File Compatibility
 
@@ -172,7 +172,7 @@ envcrypt --decrypt --legacy --password "$PASSPHRASE" .env.enc .env
 envcrypt --encrypt --password "$PASSPHRASE" .env .env.enc
 ```
 
-If the pass phrase is stored in an environment variable or file, use `--environ NAME` or `--file PATH` instead of `--password`.
+If the passphrase is stored in an environment variable or file, use `--environ NAME` or `--file PATH` instead of `--password`.
 After migration, verify the new file can be decrypted by envex 5.0.0 or later and remove any temporary plaintext file:
 
 ```shell
@@ -207,14 +207,14 @@ options:
 ```
 Either `--encrypt` or `--decrypt` must be provided
 
-A pass phrase is required, one of `--password`, `--environ`, or `--file` must also be given. If the pass phrase is not provided, the utility will prompt for it stdin is available and is a terminal.
+A passphrase is required, one of `--password`, `--environ`, or `--file` must also be given. If the passphrase is not provided, the utility will prompt for it stdin is available and is a terminal.
 
 After an encryption or decryption operation, the input file is retained by default, but can be removed using the `--rm` option.
 
 Specifying the output filename is optional, and if not given the utility will append `.enc` to the input filename for encryption, or remove `.enc` for decryption. The --rm option will remove the input file on success.
 
 Note that similar to use of the Vault option, the value of encrypted variables is not published (exported) to the process environment unless the "export" prefix is used in the decrypted environment file, and therefore remains hidden from external processes.
-However, the pass phrase must be available in order for the environment to be read, and therefore the security of the encrypted file is only as strong as the security of that pass phrase.
+However, the passphrase must be available in order for the environment to be read, and therefore the security of the encrypted file is only as strong as the security of that passphrase.
 
 Three options are available when using the `Env` class to read encrypted environment files.
 A value passed to the password parameter can be a string which is by default the plain text passphrase.

--- a/README.md
+++ b/README.md
@@ -149,10 +149,35 @@ This is enforced by the underlying os.environ, but also true of any provided env
 ## Encrypted Environment Files
 
 To enhance security of environment files that exist on the filesystem `envex` supports the creation and use of authenticated AES-256-GCM encrypted files.
+Version 5.0.0 changes the encrypted file format from the legacy AES-CBC format to AES-GCM because the old format did not authenticate ciphertext and was vulnerable to padding-oracle style attacks if decryption failures were exposed.
+The new format authenticates encrypted data before returning plaintext and is not subject to that vulnerability.
 
 Encrypted `.env` files are named as `.env.enc` by default (strictly, `${DOTENV:-.env}.enc`), to distinguish them from the unencrypted version, but this is only by convention; both to distinguish the files visually, and to prevent other dot-env readers from using them.
 
 If the feature is enabled and a pass phrase is provided when the environment file is read, `envex` determines automatically if it contains encrypted data. If the `.enc` version of the environment file does not exist, the .env file - encrypted or not - is used as a fallback, but will otherwise be ignored.
+
+### Version 5 Encrypted File Compatibility
+
+This is a breaking encrypted-file format change:
+
+- Files encrypted by envex 5.0.0 and later cannot be decrypted by envex 4.x or older.
+- Envex 5.0.0 can still decrypt legacy AES-CBC files so existing files can be migrated.
+- Any file re-encrypted with envex 5.0.0 will require envex 5.0.0 or later to decrypt.
+
+To migrate an existing encrypted file, decrypt it with a version that can read the current file, then re-encrypt it with envex 5.0.0 or later:
+
+```shell
+envcrypt --decrypt --password "$PASSPHRASE" .env.enc .env
+envcrypt --encrypt --password "$PASSPHRASE" .env .env.enc
+```
+
+If the pass phrase is stored in an environment variable or file, use `--environ NAME` or `--file PATH` instead of `--password`.
+After migration, verify the new file can be decrypted by envex 5.0.0 or later and remove any temporary plaintext file:
+
+```shell
+envcrypt --decrypt --password "$PASSPHRASE" .env.enc .env.verify
+rm .env .env.verify
+```
 
 The `envcrypt` CLI utility supports the encryption and decryption of environment files.
 ```shell

--- a/README.md
+++ b/README.md
@@ -197,8 +197,8 @@ options:
 -E, --environ ENVIRON    Read password from provided environment variable (default: None)
 -F, --file FILE          Read password from a given file (default: None)
 
--e, --encrypt            Use given password (default: False)
--d, --decrypt            Read password from provided environment variable (default: False)
+-e, --encrypt            Encrypt input (default: False)
+-d, --decrypt            Decrypt input (default: False)
 --legacy                 Allow decrypting legacy AES-CBC files for migration (default: False)
 
 -r, --rm                 Remove input file after successful conversion (default: False)

--- a/envex/env_crypto.py
+++ b/envex/env_crypto.py
@@ -14,6 +14,8 @@ from typing import Union
 # existing AES-CBC files can still be detected and decrypted.
 MAGIC_BYTES = b"SECF"  # "Secure Encrypted File"
 AUTH_MAGIC_BYTES = b"SECG"
+if len(MAGIC_BYTES) != len(AUTH_MAGIC_BYTES):
+    raise RuntimeError("Encrypted file magic headers must have equal lengths")
 ITERATIONS = 1800000
 AES_KEY_LENGTH = 32  # max bytes for AES256
 SALT_LENGTH = 16
@@ -90,6 +92,9 @@ try:
             raise DecryptError(DECRYPT_ERROR_MESSAGE)
         return data
 
+    def _read_magic(input_stream: BytesIO) -> bytes:
+        return input_stream.read(len(MAGIC_BYTES))
+
     def encrypt_data(
         input_stream: Union[BytesIO, TextIOBase], password: str, encoding: str = "utf-8"
     ) -> BytesIO:
@@ -97,7 +102,7 @@ try:
         Encrypt a file using AES-256-GCM with a password-derived key.
         """
         input_stream = _read_stream(input_stream, encoding)
-        first_bytes = input_stream.read(max(len(MAGIC_BYTES), len(AUTH_MAGIC_BYTES)))
+        first_bytes = _read_magic(input_stream)
         if first_bytes in (MAGIC_BYTES, AUTH_MAGIC_BYTES):
             logger.debug("Attempted to encrypt an already encrypted stream")
             raise EncryptError("This data is already encrypted")
@@ -138,10 +143,8 @@ try:
         logger.debug(f"Decryption successful ({len(decrypted_data)} bytes)")
         return BytesIO(decrypted_data)
 
-    def _decrypt_legacy_cbc(
-        input_stream: BytesIO, password: str, salt_prefix: bytes
-    ) -> BytesIO:
-        salt = salt_prefix + _read_exact(input_stream, SALT_LENGTH - len(salt_prefix))
+    def _decrypt_legacy_cbc(input_stream: BytesIO, password: str) -> BytesIO:
+        salt = _read_exact(input_stream, SALT_LENGTH)
         iv = _read_exact(input_stream, LEGACY_IV_LENGTH)
         encrypted_data = input_stream.read()
         key, _ = generate_key_from_password(password, salt)
@@ -159,15 +162,15 @@ try:
         """
         Decrypt data that was encrypted using encrypt_data()
         """
-        header = input_stream.read(len(AUTH_MAGIC_BYTES))
+        header = _read_magic(input_stream)
         if header == AUTH_MAGIC_BYTES:
             return _decrypt_gcm(input_stream, password)
-        if not header.startswith(MAGIC_BYTES):
+        if header != MAGIC_BYTES:
             logger.debug("Attempted to decrypt a non-encrypted stream")
             raise DecryptError("This data does not look to be encrypted")
         if not allow_legacy:
             raise DecryptError("Legacy AES-CBC data requires explicit legacy decryption")
-        return _decrypt_legacy_cbc(input_stream, password, header[len(MAGIC_BYTES) :])
+        return _decrypt_legacy_cbc(input_stream, password)
 
 
 except ImportError as e:

--- a/envex/env_crypto.py
+++ b/envex/env_crypto.py
@@ -153,7 +153,9 @@ try:
         logger.debug(f"Legacy decryption successful ({len(decrypted_data)} bytes)")
         return BytesIO(decrypted_data)
 
-    def decrypt_data(input_stream: BytesIO, password: str) -> BytesIO:
+    def decrypt_data(
+        input_stream: BytesIO, password: str, *, allow_legacy: bool = False
+    ) -> BytesIO:
         """
         Decrypt data that was encrypted using encrypt_data()
         """
@@ -163,6 +165,8 @@ try:
         if not header.startswith(MAGIC_BYTES):
             logger.debug("Attempted to decrypt a non-encrypted stream")
             raise DecryptError("This data does not look to be encrypted")
+        if not allow_legacy:
+            raise DecryptError("Legacy AES-CBC data requires explicit legacy decryption")
         return _decrypt_legacy_cbc(input_stream, password, header[len(MAGIC_BYTES) :])
 
 
@@ -176,5 +180,7 @@ except ImportError as e:
     def encrypt_data(_input_stream: BytesIO, _password: str) -> BytesIO:
         raise EncryptError("Encryption not supported")
 
-    def decrypt_data(_input_stream: BytesIO, _password: str) -> BytesIO:
+    def decrypt_data(
+        _input_stream: BytesIO, _password: str, *, allow_legacy: bool = False
+    ) -> BytesIO:
         raise DecryptError("Decryption not supported")

--- a/envex/env_crypto.py
+++ b/envex/env_crypto.py
@@ -1,5 +1,5 @@
 """
-Block data encryption using
+Block data encryption using authenticated AES-256-GCM.
 """
 
 import logging
@@ -10,10 +10,17 @@ __all__ = ("encrypt_data", "decrypt_data", "EncryptError", "DecryptError")
 
 from typing import Union
 
-# Magic bytes to identify an encrypted files
+# Magic bytes to identify encrypted files. The legacy prefix is retained so
+# existing AES-CBC files can still be detected and decrypted.
 MAGIC_BYTES = b"SECF"  # "Secure Encrypted File"
+AUTH_MAGIC_BYTES = b"SECG"
 ITERATIONS = 1800000
 AES_KEY_LENGTH = 32  # max bytes for AES256
+SALT_LENGTH = 16
+LEGACY_IV_LENGTH = 16
+GCM_NONCE_LENGTH = 12
+GCM_TAG_LENGTH = 16
+DECRYPT_ERROR_MESSAGE = "Incorrect password or invalid data"
 
 logger = logging.getLogger(__file__)
 
@@ -43,11 +50,11 @@ try:
         """
         Check and remove PKCS7 padding
         """
-        padding_length = data[-1]
+        padding_length = data[-1] if data else 0
         if padding_length < 1 or padding_length > AES.block_size:
-            raise ValueError("Invalid padding length")
+            raise ValueError("Invalid padding")
         if data[-padding_length:] != bytes([padding_length]) * padding_length:
-            raise ValueError("Invalid padding bytes")
+            raise ValueError("Invalid padding")
         return data[:-padding_length]
 
     def generate_key_from_password(
@@ -69,17 +76,29 @@ try:
         )
         return key, salt
 
+    def _read_stream(input_stream: Union[BytesIO, TextIOBase], encoding: str) -> BytesIO:
+        if not isinstance(input_stream, BytesIO):
+            input_stream.seek(0)
+            data = input_stream.read()
+            data = data.encode(encoding) if isinstance(data, str) else data
+            input_stream = BytesIO(data)
+        return input_stream
+
+    def _read_exact(input_stream: BytesIO, size: int) -> bytes:
+        data = input_stream.read(size)
+        if len(data) != size:
+            raise DecryptError(DECRYPT_ERROR_MESSAGE)
+        return data
+
     def encrypt_data(
         input_stream: Union[BytesIO, TextIOBase], password: str, encoding: str = "utf-8"
     ) -> BytesIO:
         """
-        Encrypt a file using AES-256 in CBC mode with a password-derived key
+        Encrypt a file using AES-256-GCM with a password-derived key.
         """
-        if not isinstance(input_stream, BytesIO):
-            input_stream.seek(0)
-            input_stream = BytesIO(input_stream.read().encode(encoding))
-        first_bytes = input_stream.read(len(MAGIC_BYTES))
-        if first_bytes == MAGIC_BYTES:
+        input_stream = _read_stream(input_stream, encoding)
+        first_bytes = input_stream.read(max(len(MAGIC_BYTES), len(AUTH_MAGIC_BYTES)))
+        if first_bytes in (MAGIC_BYTES, AUTH_MAGIC_BYTES):
             logger.debug("Attempted to encrypt an already encrypted stream")
             raise EncryptError("This data is already encrypted")
         input_stream.seek(0)
@@ -90,49 +109,61 @@ try:
 
         key, salt = generate_key_from_password(password)
 
-        # Generate random IV
-        iv = secrets.token_bytes(16)
+        nonce = secrets.token_bytes(GCM_NONCE_LENGTH)
 
         try:
-            # Create cipher
-            cipher = AES.new(key, AES.MODE_CBC, iv)
-
-            # Pad and encrypt the data
-            encrypted_data = cipher.encrypt(_pad(input_stream.getvalue()))
+            cipher = AES.new(key, AES.MODE_GCM, nonce=nonce)
+            encrypted_data, tag = cipher.encrypt_and_digest(input_stream.getvalue())
         except ValueError as exc:
             raise DecryptError(*exc.args) from exc
 
-        logger.debug(f"Encryption successful ({len(encrypted_data)} + 36 bytes)")
+        logger.debug(
+            f"Encryption successful ({len(encrypted_data)} + "
+            f"{len(AUTH_MAGIC_BYTES) + SALT_LENGTH + GCM_NONCE_LENGTH + GCM_TAG_LENGTH} bytes)"
+        )
 
-        # Write magic bytes, salt, IV, and encrypted data
-        return BytesIO(MAGIC_BYTES + salt + iv + encrypted_data)
+        return BytesIO(AUTH_MAGIC_BYTES + salt + nonce + tag + encrypted_data)
+
+    def _decrypt_gcm(input_stream: BytesIO, password: str) -> BytesIO:
+        salt = _read_exact(input_stream, SALT_LENGTH)
+        nonce = _read_exact(input_stream, GCM_NONCE_LENGTH)
+        tag = _read_exact(input_stream, GCM_TAG_LENGTH)
+        encrypted_data = input_stream.read()
+        key, _ = generate_key_from_password(password, salt)
+        try:
+            cipher = AES.new(key, AES.MODE_GCM, nonce=nonce)
+            decrypted_data = cipher.decrypt_and_verify(encrypted_data, tag)
+        except ValueError as exc:
+            raise DecryptError(DECRYPT_ERROR_MESSAGE) from exc
+        logger.debug(f"Decryption successful ({len(decrypted_data)} bytes)")
+        return BytesIO(decrypted_data)
+
+    def _decrypt_legacy_cbc(
+        input_stream: BytesIO, password: str, salt_prefix: bytes
+    ) -> BytesIO:
+        salt = salt_prefix + _read_exact(input_stream, SALT_LENGTH - len(salt_prefix))
+        iv = _read_exact(input_stream, LEGACY_IV_LENGTH)
+        encrypted_data = input_stream.read()
+        key, _ = generate_key_from_password(password, salt)
+        try:
+            cipher = AES.new(key, AES.MODE_CBC, iv)
+            decrypted_data = _unpad(cipher.decrypt(encrypted_data))
+        except ValueError as exc:
+            raise DecryptError(DECRYPT_ERROR_MESSAGE) from exc
+        logger.debug(f"Legacy decryption successful ({len(decrypted_data)} bytes)")
+        return BytesIO(decrypted_data)
 
     def decrypt_data(input_stream: BytesIO, password: str) -> BytesIO:
         """
         Decrypt data that was encrypted using encrypt_data()
         """
-        # Read the magic bytes, salt, IV, and encrypted data
-        magic = input_stream.read(len(MAGIC_BYTES))
-        if magic != MAGIC_BYTES:
+        header = input_stream.read(len(AUTH_MAGIC_BYTES))
+        if header == AUTH_MAGIC_BYTES:
+            return _decrypt_gcm(input_stream, password)
+        if not header.startswith(MAGIC_BYTES):
             logger.debug("Attempted to decrypt a non-encrypted stream")
             raise DecryptError("This data does not look to be encrypted")
-        salt = input_stream.read(16)  # salt
-        iv = input_stream.read(16)  # IV
-        encrypted_data = input_stream.read()
-
-        # Regenerate the key using the same password and salt
-        key, _ = generate_key_from_password(password, salt)
-
-        # Create cipher
-        try:
-            cipher = AES.new(key, AES.MODE_CBC, iv)
-            padded_decrypted_data = cipher.decrypt(encrypted_data)
-            # Decrypt and unpad the data
-            decrypted_data = _unpad(padded_decrypted_data)
-        except ValueError as e:
-            raise DecryptError("Incorrect password or invalid data") from e
-        logger.debug(f"Decryption successful ({len(decrypted_data)} bytes)")
-        return BytesIO(decrypted_data)
+        return _decrypt_legacy_cbc(input_stream, password, header[len(MAGIC_BYTES) :])
 
 
 except ImportError as e:

--- a/envex/env_crypto.py
+++ b/envex/env_crypto.py
@@ -120,7 +120,7 @@ try:
             cipher = AES.new(key, AES.MODE_GCM, nonce=nonce)
             encrypted_data, tag = cipher.encrypt_and_digest(input_stream.getvalue())
         except ValueError as exc:
-            raise DecryptError(*exc.args) from exc
+            raise EncryptError("Encryption failed") from exc
 
         logger.debug(
             f"Encryption successful ({len(encrypted_data)} + "

--- a/envex/scripts/envcrypt.py
+++ b/envex/scripts/envcrypt.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 """
-File encrypt/decrypt (AES-256-CBC with HMAC-SHA256)
+File encrypt/decrypt (authenticated AES-256-GCM)
 """
 
 import os

--- a/envex/scripts/envcrypt.py
+++ b/envex/scripts/envcrypt.py
@@ -116,6 +116,12 @@ def main():
     )
 
     parser.add_argument(
+        "--legacy",
+        action="store_true",
+        default=False,
+        help="Allow decrypting legacy AES-CBC files for migration",
+    )
+    parser.add_argument(
         "-r",
         "--rm",
         action="store_true",
@@ -164,6 +170,9 @@ def main():
             "{parser.prog}: operation to perform (--encrypt or --decrypt) must be specified"
         )
         exit(3)
+    if args.legacy and args.encrypt:
+        logger.error(f"{parser.prog}: --legacy can only be used with --decrypt")
+        exit(3)
 
     encrypt = args.encrypt
 
@@ -195,9 +204,14 @@ def main():
         f"{parser.prog}: {'encrypt' if encrypt else 'decrypt'} {_input} -> {_output}"
     )
 
-    func = encrypt_data if encrypt else decrypt_data
     try:
-        _output.write_bytes(func(BytesIO(_input.read_bytes()), _password).getvalue())
+        input_data = BytesIO(_input.read_bytes())
+        output_data = (
+            encrypt_data(input_data, _password)
+            if encrypt
+            else decrypt_data(input_data, _password, allow_legacy=args.legacy)
+        )
+        _output.write_bytes(output_data.getvalue())
     except DecryptError as e:
         logger.error(f"{parser.prog}: {e.args}")
         exit(4)

--- a/envex/scripts/envcrypt.py
+++ b/envex/scripts/envcrypt.py
@@ -10,7 +10,7 @@ import string
 from io import BytesIO
 from pathlib import Path
 
-from envex.env_crypto import encrypt_data, decrypt_data, DecryptError
+from envex.env_crypto import encrypt_data, decrypt_data, DecryptError, EncryptError
 
 ENCRYPTED_EXT = ".enc"
 
@@ -105,14 +105,14 @@ def main():
 
     encrypt_opts = parser.add_mutually_exclusive_group()
     encrypt_opts.add_argument(
-        "-e", "--encrypt", action="store_true", default=False, help="Use given password"
+        "-e", "--encrypt", action="store_true", default=False, help="Encrypt input"
     )
     encrypt_opts.add_argument(
         "-d",
         "--decrypt",
         action="store_true",
         default=False,
-        help="Read password from provided environment variable",
+        help="Decrypt input",
     )
 
     parser.add_argument(
@@ -167,7 +167,7 @@ def main():
 
     if not args.encrypt and not args.decrypt:
         logger.error(
-            "{parser.prog}: operation to perform (--encrypt or --decrypt) must be specified"
+            f"{parser.prog}: operation to perform (--encrypt or --decrypt) must be specified"
         )
         exit(3)
     if args.legacy and args.encrypt:
@@ -212,8 +212,8 @@ def main():
             else decrypt_data(input_data, _password, allow_legacy=args.legacy)
         )
         _output.write_bytes(output_data.getvalue())
-    except DecryptError as e:
-        logger.error(f"{parser.prog}: {e.args}")
+    except (EncryptError, DecryptError) as e:
+        logger.error(f"{parser.prog}: {e}")
         exit(4)
 
     if args.rm:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "envex"
-version = "4.4.0"
+version = "5.0.0"
 description = "Environment interface with (optionally encrypted) .env with hashicorp vault support"
 readme = "README.md"
 license = { file = "LICENSE.md" }

--- a/tests/test_env_crypto.py
+++ b/tests/test_env_crypto.py
@@ -3,6 +3,7 @@
 from io import BytesIO, StringIO
 
 import pytest
+import envex.env_crypto as env_crypto
 from envex.env_crypto import encrypt_data, decrypt_data, EncryptError, DecryptError
 
 
@@ -29,6 +30,7 @@ def test_encrypt_data_success(password):
     result = encrypt_data(input_data, password)
     assert isinstance(result, BytesIO)
     assert result.getvalue() != b"test data"  # Ensure data is encrypted
+    assert result.getvalue().startswith(env_crypto.AUTH_MAGIC_BYTES)
 
 
 def test_encrypt_decrypt_unicode_(password):
@@ -79,6 +81,16 @@ def test_valid_decryption(password):
     assert result.getvalue() == b"VALID_ENCRYPTED_DATA"
 
 
+def test_tampered_ciphertext_fails_authentication(password):
+    encrypted_data = bytearray(
+        encrypt_data(BytesIO(b"VALID_ENCRYPTED_DATA"), password).getvalue()
+    )
+    encrypted_data[-1] ^= 1
+    with pytest.raises(DecryptError) as e:
+        decrypt_data(BytesIO(encrypted_data), password)
+    assert str(e.value) == "Incorrect password or invalid data"
+
+
 def test_invalid_magic_bytes(encrypted_stream_with_invalid_magic_bytes, password):
     # Ensure decryption fails on invalid magic bytes
     with pytest.raises(DecryptError) as e:
@@ -93,6 +105,32 @@ def test_invalid_password(incorrect_password, password):
     with pytest.raises(DecryptError) as e:
         decrypt_data(encrypted_data, incorrect_password)
     assert "Incorrect password or invalid data" in str(e.value)
+
+
+def legacy_encrypt_data(data: bytes, password: str) -> BytesIO:
+    salt = b"salt_for_tests_1"
+    iv = b"iv_for_tests__01"
+    key, _ = env_crypto.generate_key_from_password(password, salt)
+    cipher = env_crypto.AES.new(key, env_crypto.AES.MODE_CBC, iv)
+    return BytesIO(
+        env_crypto.MAGIC_BYTES + salt + iv + cipher.encrypt(env_crypto._pad(data))
+    )
+
+
+def test_legacy_cbc_decryption_remains_supported(password):
+    encrypted_data = legacy_encrypt_data(b"LEGACY_ENCRYPTED_DATA", password)
+    result = decrypt_data(encrypted_data, password)
+    assert result.getvalue() == b"LEGACY_ENCRYPTED_DATA"
+
+
+def test_legacy_cbc_padding_failures_are_generic(password):
+    encrypted_data = bytearray(
+        legacy_encrypt_data(b"LEGACY_ENCRYPTED_DATA", password).getvalue()
+    )
+    encrypted_data[-1] ^= 1
+    with pytest.raises(DecryptError) as e:
+        decrypt_data(BytesIO(encrypted_data), password)
+    assert str(e.value) == "Incorrect password or invalid data"
 
 
 def test_empty_stream(password):

--- a/tests/test_env_crypto.py
+++ b/tests/test_env_crypto.py
@@ -119,8 +119,23 @@ def legacy_encrypt_data(data: bytes, password: str) -> BytesIO:
 
 def test_legacy_cbc_decryption_remains_supported(password):
     encrypted_data = legacy_encrypt_data(b"LEGACY_ENCRYPTED_DATA", password)
-    result = decrypt_data(encrypted_data, password)
+    result = decrypt_data(encrypted_data, password, allow_legacy=True)
     assert result.getvalue() == b"LEGACY_ENCRYPTED_DATA"
+
+
+def test_legacy_cbc_decryption_requires_opt_in(password):
+    encrypted_data = legacy_encrypt_data(b"LEGACY_ENCRYPTED_DATA", password)
+    with pytest.raises(DecryptError) as e:
+        decrypt_data(encrypted_data, password)
+    assert str(e.value) == "Legacy AES-CBC data requires explicit legacy decryption"
+
+
+def test_downgraded_gcm_header_does_not_fall_back_to_legacy(password):
+    encrypted_data = bytearray(encrypt_data(BytesIO(b"test"), password).getvalue())
+    encrypted_data[: len(env_crypto.AUTH_MAGIC_BYTES)] = env_crypto.MAGIC_BYTES
+    with pytest.raises(DecryptError) as e:
+        decrypt_data(BytesIO(encrypted_data), password)
+    assert str(e.value) == "Legacy AES-CBC data requires explicit legacy decryption"
 
 
 def test_legacy_cbc_padding_failures_are_generic(password):
@@ -129,7 +144,7 @@ def test_legacy_cbc_padding_failures_are_generic(password):
     )
     encrypted_data[-1] ^= 1
     with pytest.raises(DecryptError) as e:
-        decrypt_data(BytesIO(encrypted_data), password)
+        decrypt_data(BytesIO(encrypted_data), password, allow_legacy=True)
     assert str(e.value) == "Incorrect password or invalid data"
 
 

--- a/tests/test_env_crypto.py
+++ b/tests/test_env_crypto.py
@@ -58,6 +58,17 @@ def test_encrypt_data_already_encrypted(password):
         encrypt_data(input_enc, password)
 
 
+def test_encrypt_data_value_error_raises_encrypt_error(password, monkeypatch):
+    class BrokenCipher:
+        def encrypt_and_digest(self, _data):
+            raise ValueError("cipher failed")
+
+    monkeypatch.setattr(env_crypto.AES, "new", lambda *args, **kwargs: BrokenCipher())
+    with pytest.raises(EncryptError) as e:
+        encrypt_data(BytesIO(b"test data"), password)
+    assert str(e.value) == "Encryption failed"
+
+
 def test_encrypt_empty_data():
     input_data = BytesIO(b"")
     password = "strongpassword123"

--- a/uv.lock
+++ b/uv.lock
@@ -193,7 +193,7 @@ wheels = [
 
 [[package]]
 name = "envex"
-version = "4.4.0"
+version = "5.0.0"
 source = { editable = "." }
 dependencies = [
     { name = "pycryptodome" },


### PR DESCRIPTION
Overview

- The legacy encrypted environment file format used AES-CBC without ciphertext authentication, which could expose decrypted data integrity risks if encrypted files were tampered with.
- This change moves new encrypted environment files to an authenticated format and treats the encrypted file format change as a v5 breaking change.

Changes

- Encrypt new environment files with authenticated AES-256-GCM.
- Reject tampered AES-GCM data before plaintext is returned.
- Require explicit legacy mode to decrypt old AES-CBC files for migration, preventing modified v5 files from falling back to the unauthenticated legacy path.
- Preserve a migration path for existing encrypted files through the envcrypt CLI.
- Bump package metadata to 5.0.0 and document the encrypted-file compatibility boundary.

Impact of the change

- Files encrypted by envex 5.0.0 and later cannot be decrypted by envex 4.x or older.
- Existing AES-CBC encrypted files require explicit legacy migration mode before re-encryption.
- Newly encrypted files are authenticated and are not subject to the unauthenticated legacy CBC weakness.

Notes

- No issue reference was provided.
- Additional fixes identified in the broader review are planned for separate branches and pull requests.