### PR TITLE
Fix Vault skip verify parsing

### DIFF
--- a/envex/env_wrapper.py
+++ b/envex/env_wrapper.py
@@ -34,7 +34,7 @@ class Env:
         url: str | None = None,
         token: str | None = None,
         cert=None,
-        verify: bool | str = True,
+        verify: bool | str | None = True,
         base_path: str | None = None,
         engine: str | None = None,
         mount_point: str | None = None,
@@ -60,7 +60,9 @@ class Env:
         @param url: (optional) vault url, default is $VAULT_ADDR
         @param token: (optional) vault token, default is $VAULT_TOKEN or ~/.vault-token
         @param cert: (optional) tuple (cert, key) or str path to client cert/key files
-        @param verify: (optional) bool | str whether to verify server cert or set ca cert path (default=True)
+        @param verify: (optional) bool | str | None whether to verify server cert,
+            set ca cert path, or derive verification from VAULT_SKIP_VERIFY when
+            None (default=True)
         @param base_path: (optional) str base path for secrets (default=None)
         @param engine: (optional) str vault secrets engine (default=None)
         @param mount_point: (optional) str vault secrets mount point (default=None, determined by engine)

--- a/envex/env_wrapper.py
+++ b/envex/env_wrapper.py
@@ -93,13 +93,16 @@ class Env:
             self.read_env(**kwargs)
         self.read_streams(*streams, **kwargs)
         self.env_source = self.env.get("ENVEX_SOURCE", "env") == "env"
+        vault_verify = (
+            verify
+            if verify is not None
+            else not self.bool("VAULT_SKIP_VERIFY", default=False)
+        )
         self.secret_manager = SecretsManager(
             url=url,
             token=token,
             cert=cert,
-            verify=verify
-            if verify is not None
-            else not self.env.get("VAULT_SKIP_VERIFY", False),
+            verify=vault_verify,
             base_path=base_path,
             engine=engine,
             mount_point=mount_point,

--- a/tests/test_wrapper.py
+++ b/tests/test_wrapper.py
@@ -178,6 +178,60 @@ def test_env_bool_rejects_invalid_strings(value):
         env.bool("FLAG")
 
 
+@pytest.mark.parametrize(
+    ("skip_verify", "expected_verify"),
+    [
+        (None, True),
+        ("false", True),
+        ("0", True),
+        ("true", False),
+        ("1", False),
+    ],
+)
+def test_vault_skip_verify_uses_strict_boolean_parsing(
+    skip_verify, expected_verify, monkeypatch
+):
+    class FakeSecretsManager:
+        calls = []
+
+        def __init__(self, **kwargs):
+            self.calls.append(kwargs)
+
+    environ = {}
+    if skip_verify is not None:
+        environ["VAULT_SKIP_VERIFY"] = skip_verify
+
+    monkeypatch.setattr("envex.env_wrapper.SecretsManager", FakeSecretsManager)
+    envex.Env(environ=environ, verify=None)
+
+    assert FakeSecretsManager.calls[-1]["verify"] is expected_verify
+
+
+@pytest.mark.parametrize("verify", [True, False, "/path/to/ca.pem"])
+def test_explicit_vault_verify_overrides_skip_verify(verify, monkeypatch):
+    class FakeSecretsManager:
+        calls = []
+
+        def __init__(self, **kwargs):
+            self.calls.append(kwargs)
+
+    monkeypatch.setattr("envex.env_wrapper.SecretsManager", FakeSecretsManager)
+    envex.Env(environ={"VAULT_SKIP_VERIFY": "true"}, verify=verify)
+
+    assert FakeSecretsManager.calls[-1]["verify"] == verify
+
+
+def test_invalid_vault_skip_verify_raises_value_error(monkeypatch):
+    class FakeSecretsManager:
+        def __init__(self, **kwargs):
+            raise AssertionError("SecretsManager should not be initialized")
+
+    monkeypatch.setattr("envex.env_wrapper.SecretsManager", FakeSecretsManager)
+
+    with pytest.raises(ValueError):
+        envex.Env(environ={"VAULT_SKIP_VERIFY": "treu"}, verify=None)
+
+
 def test_is_set_uses_secret_manager_values():
     class FakeSecretsManager:
         def __init__(self, secrets):


### PR DESCRIPTION
Overview

- VAULT_SKIP_VERIFY was previously interpreted using raw string truthiness when Env derived Vault TLS verification.
- String values such as "false" could therefore disable TLS verification instead of preserving the safe default.

Changes

- Parse VAULT_SKIP_VERIFY through the strict Env boolean parser when verify is not explicitly provided.
- Preserve explicit verify argument precedence, including boolean values and CA path strings.
- Reject malformed skip-verify values instead of silently changing TLS behavior.

Impact of the change

- Unset, false-like, or zero-like VAULT_SKIP_VERIFY values keep Vault TLS verification enabled.
- True-like values disable verification only when the caller opts into environment-derived verification by passing verify=None.
- Invalid values now fail fast and do not initialize the Vault secret manager.

Notes

- No issue reference was provided.
- Additional review findings are being handled in separate branches and pull requests.