### PR TITLE
UT-183 Fix seal CLI status handling

### DIFF
--- a/envex/scripts/seal.py
+++ b/envex/scripts/seal.py
@@ -77,9 +77,8 @@ def main():
 
     args = parser.parse_args()
 
-    client = hvac.Client(
-        url=args.address, token=args.token, verify=expand(args.cacert) or False
-    )
+    verify = expand(args.cacert) if args.cacert else True
+    client = hvac.Client(url=args.address, token=args.token, verify=verify)
 
     try:
         if args.seal:
@@ -97,7 +96,7 @@ def main():
         status = client.seal_status
         print(
             trim_indent(
-                f"Vault Status: {'Sealed' if status['sealed'] == 'true' else 'Unsealed'} "
+                f"Vault Status: {'Sealed' if status['sealed'] else 'Unsealed'} "
                 f"type={status['type']} shares={status['t']}/{status['n']}"
             )
         )

--- a/tests/test_seal_script.py
+++ b/tests/test_seal_script.py
@@ -15,11 +15,11 @@ from envex.scripts import seal
 def test_seal_status_uses_boolean_value_and_default_verify(
     sealed, expected_status, monkeypatch, capsys
 ):
-    class FakeClient:
-        calls = []
+    calls = []
 
+    class FakeClient:
         def __init__(self, **kwargs):
-            self.calls.append(kwargs)
+            calls.append(kwargs)
             self.seal_status = {
                 "sealed": sealed,
                 "type": "shamir",
@@ -35,18 +35,18 @@ def test_seal_status_uses_boolean_value_and_default_verify(
 
     seal.main()
 
-    assert FakeClient.calls[-1]["verify"] is True
+    assert calls[-1]["verify"] is True
     assert capsys.readouterr().out.strip() == (
         f"Vault Status: {expected_status} type=shamir shares=3/5"
     )
 
 
 def test_seal_expands_cacert_path(monkeypatch, capsys):
-    class FakeClient:
-        calls = []
+    calls = []
 
+    class FakeClient:
         def __init__(self, **kwargs):
-            self.calls.append(kwargs)
+            calls.append(kwargs)
             self.seal_status = {
                 "sealed": False,
                 "type": "shamir",
@@ -72,5 +72,5 @@ def test_seal_expands_cacert_path(monkeypatch, capsys):
 
     seal.main()
 
-    assert FakeClient.calls[-1]["verify"] == "/tmp/envex-home/ca.pem"
+    assert calls[-1]["verify"] == "/tmp/envex-home/ca.pem"
     assert "Vault Status: Unsealed" in capsys.readouterr().out

--- a/tests/test_seal_script.py
+++ b/tests/test_seal_script.py
@@ -1,0 +1,76 @@
+import sys
+
+import pytest
+
+from envex.scripts import seal
+
+
+@pytest.mark.parametrize(
+    ("sealed", "expected_status"),
+    [
+        (True, "Sealed"),
+        (False, "Unsealed"),
+    ],
+)
+def test_seal_status_uses_boolean_value_and_default_verify(
+    sealed, expected_status, monkeypatch, capsys
+):
+    class FakeClient:
+        calls = []
+
+        def __init__(self, **kwargs):
+            self.calls.append(kwargs)
+            self.seal_status = {
+                "sealed": sealed,
+                "type": "shamir",
+                "t": 3,
+                "n": 5,
+            }
+
+    monkeypatch.delenv("VAULT_CACERT", raising=False)
+    monkeypatch.setattr(seal.hvac, "Client", FakeClient)
+    monkeypatch.setattr(
+        sys, "argv", ["seal", "--address", "http://vault.local", "--token", "token"]
+    )
+
+    seal.main()
+
+    assert FakeClient.calls[-1]["verify"] is True
+    assert capsys.readouterr().out.strip() == (
+        f"Vault Status: {expected_status} type=shamir shares=3/5"
+    )
+
+
+def test_seal_expands_cacert_path(monkeypatch, capsys):
+    class FakeClient:
+        calls = []
+
+        def __init__(self, **kwargs):
+            self.calls.append(kwargs)
+            self.seal_status = {
+                "sealed": False,
+                "type": "shamir",
+                "t": 3,
+                "n": 5,
+            }
+
+    monkeypatch.setenv("HOME", "/tmp/envex-home")
+    monkeypatch.setattr(seal.hvac, "Client", FakeClient)
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            "seal",
+            "--address",
+            "http://vault.local",
+            "--token",
+            "token",
+            "--cacert",
+            "~/ca.pem",
+        ],
+    )
+
+    seal.main()
+
+    assert FakeClient.calls[-1]["verify"] == "/tmp/envex-home/ca.pem"
+    assert "Vault Status: Unsealed" in capsys.readouterr().out


### PR DESCRIPTION
Overview

- UT-183 addresses defects in the seal CLI when connecting to Vault and reporting seal state.
- The command could crash at startup when no CA certificate path was configured, and sealed Vaults were reported as unsealed because the status value was compared to the wrong type.

Changes

- Default Vault TLS verification to enabled when no CA certificate path is provided.
- Continue expanding an explicit CA certificate path before passing it to the Vault client.
- Report Vault seal status from the boolean status value returned by the client.

Impact of the change

- Running seal without --cacert or VAULT_CACERT no longer fails before connecting to Vault.
- The command now preserves TLS verification by default instead of turning verification off for missing CA configuration.
- Sealed and unsealed Vault states are displayed correctly.

Notes

- Linked issue: UT-183.
- Other review findings are being handled in separate branches and pull requests.