### PR TITLE
UT-184 Fix envsecrets console script entrypoint

### DIFF
--- a/envex/scripts/envsecrets.py
+++ b/envex/scripts/envsecrets.py
@@ -171,24 +171,8 @@ def create_or_update_secrets(secrets, key, cert, verbose):
         )
 
 
-def main(args):
-    search = args.search.split(",") if args.search else None
-    env = read_env(args.dotenv, search=search, parents=args.parents, useenv=args.environ)
-    data = parse_template(env, args.template, args.comments)
-    rendered = subst(env, data)
-    if secrets := output_result(rendered, args.output, args.empty):
-        create_or_update_secrets(secrets, args.key, args.cert, args.verbose)
-
-
-def error(message, exitcode=None):
-    print(f"{'ERROR' if exitcode else 'WARNING'}: {message}", file=sys.stderr)
-    if exitcode is not None:
-        exit(exitcode)
-
-
-if __name__ == "__main__":
-    prog = Path(sys.argv[0]).resolve(strict=True)
-    parser = argparse.ArgumentParser(prog=prog.name, description=__doc__)
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(prog="envsecrets", description=__doc__)
 
     scripts = Path(__file__).parent
     dotenv_default = ".env"
@@ -272,8 +256,30 @@ if __name__ == "__main__":
         default=output_default,
         help=f'output to this file (default="{output_default}")',
     )
+    return parser
 
-    argv = parser.parse_args()
-    # print(argv)
 
-    main(argv)
+def run(args: argparse.Namespace) -> None:
+    search = args.search.split(",") if args.search else None
+    env = read_env(args.dotenv, search=search, parents=args.parents, useenv=args.environ)
+    data = parse_template(env, args.template, args.comments)
+    rendered = subst(env, data)
+    if secrets := output_result(rendered, args.output, args.empty):
+        create_or_update_secrets(secrets, args.key, args.cert, args.verbose)
+
+
+def main(argv: list[str] | argparse.Namespace | None = None) -> None:
+    args = (
+        argv if isinstance(argv, argparse.Namespace) else build_parser().parse_args(argv)
+    )
+    run(args)
+
+
+def error(message, exitcode=None):
+    print(f"{'ERROR' if exitcode else 'WARNING'}: {message}", file=sys.stderr)
+    if exitcode is not None:
+        exit(exitcode)
+
+
+if __name__ == "__main__":
+    main()

--- a/envex/scripts/envsecrets.py
+++ b/envex/scripts/envsecrets.py
@@ -13,6 +13,7 @@ Output:
 import argparse
 import re
 import sys
+from collections.abc import Sequence
 from functools import cache
 from pathlib import Path
 from string import Template
@@ -253,6 +254,7 @@ def build_parser() -> argparse.ArgumentParser:
     parser.add_argument(
         "output",
         action="store",
+        nargs="?",
         default=output_default,
         help=f'output to this file (default="{output_default}")',
     )
@@ -268,7 +270,7 @@ def run(args: argparse.Namespace) -> None:
         create_or_update_secrets(secrets, args.key, args.cert, args.verbose)
 
 
-def main(argv: list[str] | argparse.Namespace | None = None) -> None:
+def main(argv: Sequence[str] | argparse.Namespace | None = None) -> None:
     args = (
         argv if isinstance(argv, argparse.Namespace) else build_parser().parse_args(argv)
     )

--- a/tests/test_envsecrets_script.py
+++ b/tests/test_envsecrets_script.py
@@ -1,0 +1,63 @@
+import sys
+
+import pytest
+
+from envex.scripts import envsecrets
+
+
+def test_main_supports_console_script_help(monkeypatch, capsys):
+    monkeypatch.setattr(sys, "argv", ["envsecrets", "--help"])
+
+    with pytest.raises(SystemExit) as exc_info:
+        envsecrets.main()
+
+    assert exc_info.value.code == 0
+    assert "usage: envsecrets" in capsys.readouterr().out
+
+
+def test_main_parses_argv_and_writes_env_and_secrets(tmp_path, monkeypatch):
+    dotenv = tmp_path / ".env"
+    dotenv.write_text("PUBLIC=hello\nSECRET=shh\n")
+    template = tmp_path / "template.env"
+    template.write_text("PUBLIC\n|SECRET\nDEFAULT=fallback\n")
+    output = tmp_path / "docker.env"
+    captured = []
+
+    def fake_create_or_update_secrets(secrets, key, cert, verbose):
+        captured.append(
+            {
+                "secrets": secrets,
+                "key": key,
+                "cert": cert,
+                "verbose": verbose,
+            }
+        )
+
+    monkeypatch.setattr(
+        envsecrets, "create_or_update_secrets", fake_create_or_update_secrets
+    )
+
+    envsecrets.main(
+        [
+            "--dotenv",
+            str(dotenv),
+            "--template",
+            str(template),
+            "--key",
+            "app",
+            str(output),
+        ]
+    )
+
+    assert output.read_text().splitlines() == [
+        "PUBLIC=hello",
+        "DEFAULT=fallback",
+    ]
+    assert captured == [
+        {
+            "secrets": {"SECRET": "shh"},
+            "key": "app",
+            "cert": None,
+            "verbose": False,
+        }
+    ]

--- a/tests/test_envsecrets_script.py
+++ b/tests/test_envsecrets_script.py
@@ -38,7 +38,7 @@ def test_main_parses_argv_and_writes_env_and_secrets(tmp_path, monkeypatch):
     )
 
     envsecrets.main(
-        [
+        (
             "--dotenv",
             str(dotenv),
             "--template",
@@ -46,7 +46,7 @@ def test_main_parses_argv_and_writes_env_and_secrets(tmp_path, monkeypatch):
             "--key",
             "app",
             str(output),
-        ]
+        )
     )
 
     assert output.read_text().splitlines() == [
@@ -61,3 +61,23 @@ def test_main_parses_argv_and_writes_env_and_secrets(tmp_path, monkeypatch):
             "verbose": False,
         }
     ]
+
+
+def test_main_uses_default_output_path(tmp_path, monkeypatch):
+    dotenv = tmp_path / ".env"
+    dotenv.write_text("PUBLIC=hello\n")
+    template = tmp_path / "template.env"
+    template.write_text("PUBLIC\n")
+
+    monkeypatch.chdir(tmp_path)
+
+    envsecrets.main(
+        [
+            "--dotenv",
+            str(dotenv),
+            "--template",
+            str(template),
+        ]
+    )
+
+    assert (tmp_path / "docker.env").read_text().splitlines() == ["PUBLIC=hello"]


### PR DESCRIPTION
Overview

- UT-184 addresses the installed envsecrets command failing immediately when invoked through the console script entrypoint.
- The script entrypoint was configured to call main() with no arguments, while the implementation required a pre-parsed argparse namespace.

Changes

- Move envsecrets argument parsing into a reusable parser path.
- Make main() callable with no arguments for installed console scripts.
- Preserve direct programmatic calls that pass an existing argparse namespace.
- Keep direct module execution on the same parser and execution path as the installed command.

Impact of the change

- Installed envsecrets invocations now parse CLI arguments instead of raising TypeError at startup.
- The help command and normal argument-driven rendering flow now work through the package entrypoint.
- Vault interaction behavior is unchanged after arguments are parsed.

Notes

- Linked issue: UT-184.
- Other review findings are being handled in separate branches and pull requests.