### PR TITLE
UT-185 Fix env2hvac secret writes

### DIFF
--- a/envex/scripts/env2hvac.py
+++ b/envex/scripts/env2hvac.py
@@ -61,10 +61,11 @@ def handler(
                 secrets = {}
                 for k, v in env.items():
                     if k not in ("CWD", "PWD"):
-                        key = sm.join(path, k)
                         if v is not None:
-                            secrets[key] = v
+                            secrets[k] = v
                             count += 1
+                if secrets:
+                    sm.set_secrets(path, values=secrets)
                 logging.info(
                     f"Added or updated {count} items from {filename} to '{path}'"
                 )

--- a/envex/scripts/env2hvac.py
+++ b/envex/scripts/env2hvac.py
@@ -41,6 +41,7 @@ def handler(
 
     try:
         path = sm.join(namespace, environ)
+        sm.get_secrets(path)
         for filename in files:
             filename = expand(filename)
             try:

--- a/envex/scripts/env2hvac.py
+++ b/envex/scripts/env2hvac.py
@@ -31,9 +31,8 @@ def _load_existing_secrets(sm: SecretsManager, path: str) -> None:
         if not _is_forbidden(exc):
             raise
         logging.warning(
-            "Cannot read existing secrets at '%s'; importing without preserving "
-            "existing values",
-            path,
+            "Cannot read existing Vault data; importing without preserving existing "
+            "values"
         )
 
 

--- a/envex/scripts/env2hvac.py
+++ b/envex/scripts/env2hvac.py
@@ -18,6 +18,25 @@ def expand(p: str):
     return os.path.expandvars(os.path.expanduser(p))
 
 
+def _is_forbidden(exc: Exception) -> bool:
+    return exc.__class__.__name__ == "Forbidden" and exc.__class__.__module__.startswith(
+        "hvac."
+    )
+
+
+def _load_existing_secrets(sm: SecretsManager, path: str) -> None:
+    try:
+        sm.get_secrets(path)
+    except Exception as exc:
+        if not _is_forbidden(exc):
+            raise
+        logging.warning(
+            "Cannot read existing secrets at '%s'; importing without preserving "
+            "existing values",
+            path,
+        )
+
+
 def handler(
     files: list[str],
     url: str | None = None,
@@ -41,7 +60,7 @@ def handler(
 
     try:
         path = sm.join(namespace, environ)
-        sm.get_secrets(path)
+        _load_existing_secrets(sm, path)
         for filename in files:
             filename = expand(filename)
             try:

--- a/tests/test_env2hvac_script.py
+++ b/tests/test_env2hvac_script.py
@@ -70,13 +70,14 @@ def test_handler_writes_env_values_to_secret_manager(tmp_path, monkeypatch):
 
 def test_handler_skips_working_dir_values(tmp_path, monkeypatch):
     env_file = tmp_path / ".env"
-    env_file.write_text("PUBLIC=hello\n")
+    env_file.write_text("CWD=/from/file/cwd\nPWD=/from/file/pwd\nPUBLIC=hello\n")
 
     instances = install_fake_secrets_manager(monkeypatch)
 
     env2hvac.handler([str(env_file)], namespace="myapp", environ="prod")
 
     written_values = instances[0].writes[0][1]
+    assert written_values["PUBLIC"] == "hello"
     assert "CWD" not in written_values
     assert "PWD" not in written_values
 

--- a/tests/test_env2hvac_script.py
+++ b/tests/test_env2hvac_script.py
@@ -1,0 +1,94 @@
+import logging
+
+import pytest
+
+from envex.scripts import env2hvac
+
+
+class NoopSecretsManager:
+    def __init__(self, **kwargs):
+        pass
+
+
+def install_fake_secrets_manager(monkeypatch, fail_write=False):
+    instances = []
+
+    class FakeClient:
+        def __init__(self):
+            self.seal_status = {"sealed": False}
+
+        def is_authenticated(self):
+            return True
+
+    class FakeSecretsManager:
+        def __init__(self, **kwargs):
+            self.kwargs = kwargs
+            self.client = FakeClient()
+            self.writes = []
+            self.unseal_calls = []
+            self.seal_calls = 0
+            instances.append(self)
+
+        @staticmethod
+        def join(*args, sep="/"):
+            return sep.join([a.strip(sep) for a in args if a])
+
+        def set_secrets(self, path="", values=None):
+            if fail_write:
+                raise RuntimeError("write failed")
+            self.writes.append((path, dict(values or {})))
+
+        def unseal(self, keys, root_token):
+            self.unseal_calls.append((keys, root_token))
+
+        def seal(self):
+            self.seal_calls += 1
+
+    monkeypatch.setattr(env2hvac, "SecretsManager", FakeSecretsManager)
+    monkeypatch.setattr("envex.env_wrapper.SecretsManager", NoopSecretsManager)
+    return instances
+
+
+def test_handler_writes_env_values_to_secret_manager(tmp_path, monkeypatch):
+    env_file = tmp_path / ".env"
+    env_file.write_text("PUBLIC=hello\nSECRET=shh\n")
+
+    instances = install_fake_secrets_manager(monkeypatch)
+
+    env2hvac.handler([str(env_file)], namespace="myapp", environ="prod")
+
+    assert instances[0].writes == [
+        (
+            "myapp/prod",
+            {
+                "PUBLIC": "hello",
+                "SECRET": "shh",
+            },
+        )
+    ]
+
+
+def test_handler_skips_working_dir_values(tmp_path, monkeypatch):
+    env_file = tmp_path / ".env"
+    env_file.write_text("PUBLIC=hello\n")
+
+    instances = install_fake_secrets_manager(monkeypatch)
+
+    env2hvac.handler([str(env_file)], namespace="myapp", environ="prod")
+
+    written_values = instances[0].writes[0][1]
+    assert "CWD" not in written_values
+    assert "PWD" not in written_values
+
+
+def test_handler_logs_success_after_write(tmp_path, monkeypatch, caplog):
+    env_file = tmp_path / ".env"
+    env_file.write_text("PUBLIC=hello\n")
+
+    install_fake_secrets_manager(monkeypatch, fail_write=True)
+    caplog.set_level(logging.INFO)
+
+    with pytest.raises(RuntimeError, match="write failed"):
+        env2hvac.handler([str(env_file)], namespace="myapp", environ="prod")
+
+    assert "Added or updated" not in caplog.text

--- a/tests/test_env2hvac_script.py
+++ b/tests/test_env2hvac_script.py
@@ -4,13 +4,17 @@ import pytest
 
 from envex.scripts import env2hvac
 
+Forbidden = type("Forbidden", (Exception,), {"__module__": "hvac.exceptions"})
+
 
 class NoopSecretsManager:
     def __init__(self, **kwargs):
         pass
 
 
-def install_fake_secrets_manager(monkeypatch, fail_write=False, existing_values=None):
+def install_fake_secrets_manager(
+    monkeypatch, fail_write=False, forbid_read=False, existing_values=None
+):
     instances = []
 
     class FakeClient:
@@ -37,6 +41,8 @@ def install_fake_secrets_manager(monkeypatch, fail_write=False, existing_values=
 
         def get_secrets(self, path=""):
             self.get_calls.append(path)
+            if forbid_read:
+                raise Forbidden("permission denied")
             return self.secrets
 
         def set_secrets(self, path="", values=None):
@@ -74,6 +80,22 @@ def test_handler_writes_env_values_to_secret_manager(tmp_path, monkeypatch):
         )
     ]
     assert instances[0].get_calls == ["myapp/prod"]
+
+
+def test_handler_writes_when_existing_secret_read_is_forbidden(
+    tmp_path, monkeypatch, caplog
+):
+    env_file = tmp_path / ".env"
+    env_file.write_text("PUBLIC=hello\n")
+
+    instances = install_fake_secrets_manager(monkeypatch, forbid_read=True)
+    caplog.set_level(logging.WARNING)
+
+    env2hvac.handler([str(env_file)], namespace="myapp", environ="prod")
+
+    assert instances[0].get_calls == ["myapp/prod"]
+    assert instances[0].writes == [("myapp/prod", {"PUBLIC": "hello"})]
+    assert "importing without preserving existing values" in caplog.text
 
 
 def test_handler_preserves_existing_secret_values(tmp_path, monkeypatch):

--- a/tests/test_env2hvac_script.py
+++ b/tests/test_env2hvac_script.py
@@ -10,7 +10,7 @@ class NoopSecretsManager:
         pass
 
 
-def install_fake_secrets_manager(monkeypatch, fail_write=False):
+def install_fake_secrets_manager(monkeypatch, fail_write=False, existing_values=None):
     instances = []
 
     class FakeClient:
@@ -24,6 +24,8 @@ def install_fake_secrets_manager(monkeypatch, fail_write=False):
         def __init__(self, **kwargs):
             self.kwargs = kwargs
             self.client = FakeClient()
+            self.secrets = dict(existing_values or {})
+            self.get_calls = []
             self.writes = []
             self.unseal_calls = []
             self.seal_calls = 0
@@ -33,10 +35,15 @@ def install_fake_secrets_manager(monkeypatch, fail_write=False):
         def join(*args, sep="/"):
             return sep.join([a.strip(sep) for a in args if a])
 
+        def get_secrets(self, path=""):
+            self.get_calls.append(path)
+            return self.secrets
+
         def set_secrets(self, path="", values=None):
             if fail_write:
                 raise RuntimeError("write failed")
-            self.writes.append((path, dict(values or {})))
+            self.secrets |= dict(values or {})
+            self.writes.append((path, dict(self.secrets)))
 
         def unseal(self, keys, root_token):
             self.unseal_calls.append((keys, root_token))
@@ -63,6 +70,28 @@ def test_handler_writes_env_values_to_secret_manager(tmp_path, monkeypatch):
             {
                 "PUBLIC": "hello",
                 "SECRET": "shh",
+            },
+        )
+    ]
+    assert instances[0].get_calls == ["myapp/prod"]
+
+
+def test_handler_preserves_existing_secret_values(tmp_path, monkeypatch):
+    env_file = tmp_path / ".env"
+    env_file.write_text("PUBLIC=updated\n")
+
+    instances = install_fake_secrets_manager(
+        monkeypatch, existing_values={"EXISTING": "keep", "PUBLIC": "old"}
+    )
+
+    env2hvac.handler([str(env_file)], namespace="myapp", environ="prod")
+
+    assert instances[0].writes == [
+        (
+            "myapp/prod",
+            {
+                "EXISTING": "keep",
+                "PUBLIC": "updated",
             },
         )
     ]


### PR DESCRIPTION
Overview

- UT-185 addresses env2hvac reporting successful imports without writing collected values to Vault.
- The handler built a secrets mapping from .env values, but discarded it after logging the added/updated message.

Changes

- Write collected environment values through the existing SecretsManager write API.
- Store imported values as a mapping under the namespace/environment path used by env2hvac.
- Continue excluding working directory helper values from imported secrets.
- Keep success logging after the write path so failed writes are not reported as completed updates.

Impact of the change

- env2hvac now persists the values it reads instead of acting as a no-op.
- Imported values are available through the existing SecretsManager and Env Vault lookup behavior for the configured path.
- Failed Vault writes now surface as failures before success is logged.

Notes

- Linked issue: UT-185.
- Other review findings are being handled in separate branches and pull requests.