### PR TITLE
Fix environment isolation and None handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 [![License: MIT](https://img.shields.io/badge/License-MIT-green.svg)](https://opensource.org/licenses/MIT)
 # ENV EXtended
 
-`envex` is a dotenv `.env` aware environment variable handler with typing features and Hashicorp vault support.
+`envex` is a dotenv `.env` aware environment variable handler with typing features and HashiCorp Vault support.
 
 ## Overview
 
@@ -31,8 +31,8 @@ Using encrypted environment files avoids using plain text files on the filesyste
 The provided `envcrypt` utility conveniently allows conversion between encrypted and non-encrypted formats.
 
 #### Vault support
-Alternatively, `envex` provides seamless integration with Hashicorp Vault. This reduces the need to store plaintext secrets on the filesystem and provides a more secure approach for managing secrets.
-Hashicorp vault functionality is optional, and is activated automatically when the `hvac` module is installed into the active virtual environment, and where connection and authentication to Vault succeed.
+Alternatively, `envex` provides seamless integration with HashiCorp Vault. This reduces the need to store plaintext secrets on the filesystem and provides a more secure approach for managing secrets.
+HashiCorp Vault functionality is optional, and is activated automatically when the `hvac` module is installed into the active virtual environment, and where connection and authentication to Vault succeed.
 Values fetched from Vault are cached by default to reduce the overhead of the api call.
 If this is of concern, caching can be disabled using the`enable_cache=False` parameter to Env.
 
@@ -237,7 +237,7 @@ Also, encrypted .env files are not available to other .env aware software.
 
 ## Vault
 
-In addition to handling of the os environment and .env files - encrypted or plain text - `envex` supports selectively fetching secrets from Hashicorp Vault using the kv.v2 engine.
+In addition to handling of the os environment and .env files - encrypted or plain text - `envex` supports selectively fetching secrets from HashiCorp Vault using the kv.v2 engine.
 This provides a secure secrets store, and completely avoids exposing secrets in plain text on the filesystem and in particular in published docker images.
 It also prevents storing secrets in the operating system’s environment, which can be inspected by external processes.
 

--- a/README.md
+++ b/README.md
@@ -1,9 +1,11 @@
+[![Maintenance](https://img.shields.io/badge/maintenance-active-brightgreen.svg)](https://github.com/deeprave/envex)
+[![PyPI version](https://img.shields.io/pypi/v/envex.svg?logo=pypi&logoColor=white)](https://pypi.org/project/envex)
+[![PyPI downloads](https://img.shields.io/pypi/dm/envex.svg?logo=pypi&logoColor=white)](https://pypi.org/project/envex)
+[![Python versions](https://img.shields.io/pypi/pyversions/envex.svg?logo=python&logoColor=white)](https://pypi.org/project/envex)
+[![License: MIT](https://img.shields.io/badge/License-MIT-green.svg)](https://opensource.org/licenses/MIT)
 # ENV EXtended
 
 `envex` is a dotenv `.env` aware environment variable handler with typing features and Hashicorp vault support.
-
-[![PyPI version](https://badge.fury.io/py/envex.svg)](https://badge.fury.io/py/envex)
-[![License: MIT](https://img.shields.io/badge/License-MIT-green.svg)](https://opensource.org/licenses/MIT)
 
 ## Overview
 
@@ -61,6 +63,8 @@ env.set('UNSET_VAR', 'this is now set')
 assert env.get('UNSET_VAR') is not None
 env.setdefault('UNSET_VAR', 'and this is a default value but only if not set')
 assert env.get('UNSET_VAR') == 'this is now set'
+env.set('UNSET_VAR', None)
+assert env.get('UNSET_VAR') is None
 del env['UNSET_VAR']
 assert env.get('UNSET_VAR') is None
 ```

--- a/envex/dot_env.py
+++ b/envex/dot_env.py
@@ -60,7 +60,6 @@ def _env_export(
 ):
     if key and val and (overwrite or key not in environ):
         environ[key] = val
-        os.environ[key] = val
 
 
 def _env_files(

--- a/envex/env_wrapper.py
+++ b/envex/env_wrapper.py
@@ -195,11 +195,15 @@ class Env:
         if isinstance(var, dict):
             for k, v in var.items():
                 self.set(k, v)
+        elif value is None:
+            self.unset(var)
         else:
-            self.env[var] = str(value) if value is not None else value
+            self.env[var] = str(value)
 
     def setdefault(self, var, value) -> str | None:
-        return self.env.setdefault(var, str(value) if value is not None else value)
+        if var not in self.env:
+            self.set(var, value)
+        return self.env.get(var)
 
     def unset(self, var):
         if var in self.env:

--- a/envex/env_wrapper.py
+++ b/envex/env_wrapper.py
@@ -11,7 +11,7 @@ from typing import Any, MutableMapping, Type
 
 from envex.env_hvac import SecretsManager
 
-from .dot_env import load_env, unquote, load_stream, update_env
+from .dot_env import load_env, unquote, load_stream
 
 
 class Env:
@@ -72,14 +72,14 @@ class Env:
         """
         self._env = self.os_env() if environ is None else environ
 
+        self.exception = exception or self._EXCEPTION_CLS
+
         streams = []
         for arg in args:
             if isinstance(arg, dict):
-                update_env(self._env, arg)
+                self.set(arg)
             elif isinstance(arg, (BytesIO, TextIOBase)):
                 streams.append(arg)
-
-        self.exception = exception or self._EXCEPTION_CLS
 
         if "streams" in kwargs and isinstance(kwargs["streams"], (tuple, list)):
             streams.extend(kwargs.pop("streams"))

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -4,10 +4,10 @@ import pytest
 try:
     import hvac
     from hvac.exceptions import InvalidRequest
+    from testcontainers.core.container import DockerContainer
+    from testcontainers.core.wait_strategies import HttpWaitStrategy
 
     use_hvac = True
-
-    from testcontainers.vault import VaultContainer
 
     container_name = "hashicorp/vault:1.14.4"
 
@@ -15,6 +15,27 @@ try:
         "ABC": "123",
         "DEF": "456",
     }
+
+    class VaultContainer(DockerContainer):
+        def __init__(
+            self,
+            image: str = container_name,
+            port: int = 8200,
+            root_token: str = "toor",
+        ) -> None:
+            super().__init__(image)
+            self.port = port
+            self.root_token = root_token
+            self.with_exposed_ports(self.port)
+            self.with_env("VAULT_DEV_ROOT_TOKEN_ID", self.root_token)
+            self.waiting_for(
+                HttpWaitStrategy(self.port, "/v1/sys/health").for_status_code(200)
+            )
+
+        def get_connection_url(self) -> str:
+            host_ip = self.get_container_host_ip()
+            exposed_port = self.get_exposed_port(self.port)
+            return f"http://{host_ip}:{exposed_port}"
 
     @pytest.fixture(scope="session")
     def vault(request) -> VaultContainer:

--- a/tests/test_load_env.py
+++ b/tests/test_load_env.py
@@ -42,6 +42,26 @@ def test_load_env(monkeypatch, envmap):
     assert env["COMBINED"] == "first-value:third-value:fifth-value"
 
 
+def test_export_command_respects_isolated_environ(monkeypatch, envmap):
+    monkeypatch.delenv("FIFTH", raising=False)
+    monkeypatch.setattr(envex.dot_env, "open_env", dotenv)
+
+    env = envex.load_env(search_path=__file__, environ=envmap, update=False)
+
+    assert env["FIFTH"] == "fifth-value"
+    assert "FIFTH" not in envex.dot_env.os.environ
+
+
+def test_export_command_updates_os_environ_only_when_requested(monkeypatch, envmap):
+    monkeypatch.delenv("FIFTH", raising=False)
+    monkeypatch.setattr(envex.dot_env, "open_env", dotenv)
+
+    env = envex.load_env(search_path=__file__, environ=envmap, update=True)
+
+    assert env["FIFTH"] == "fifth-value"
+    assert envex.dot_env.os.environ["FIFTH"] == "fifth-value"
+
+
 def test_load_env_overwrite(monkeypatch, envmap):
     monkeypatch.setattr(envex.dot_env, "open_env", dotenv)
     env = envex.load_env(search_path=__file__, environ=envmap, overwrite=True)

--- a/tests/test_wrapper.py
+++ b/tests/test_wrapper.py
@@ -56,6 +56,13 @@ def test_env_wrapper_dict():
     assert env("ENABLED") == "3"
 
 
+def test_env_wrapper_dict_none_is_unset():
+    env = envex.Env({"TEST": "one", "ARG2": None}, environ={})
+
+    assert env("TEST") == "one"
+    assert "ARG2" not in env.env
+
+
 def test_env_wrapper_stream_bytes():
     stream = io.BytesIO(b"ONE=1\nARG2=two\nENABLED=true\n")
     env = envex.Env(stream, environ={})

--- a/tests/test_wrapper.py
+++ b/tests/test_wrapper.py
@@ -396,12 +396,39 @@ def test_setdefault_non_none():
 
 def test_setdefault_none():
     env = envex.Env(environ={})
-    # Test when value is None
+
     result = env.setdefault("var2", None)
+
     assert result is None
-    assert env.env["var2"] is None
+    assert "var2" not in env.env
     env.setdefault("var2", 543)
-    assert env.env["var2"] is None
+    assert env.env["var2"] == "543"
+
+
+def test_setdefault_none_preserves_existing_value():
+    env = envex.Env({"var2": "value"}, environ={})
+
+    result = env.setdefault("var2", None)
+
+    assert result == "value"
+    assert env.env["var2"] == "value"
+
+
+def test_set_none_unsets_existing_value():
+    env = envex.Env({"var1": "value"}, environ={})
+
+    env.set("var1", None)
+
+    assert "var1" not in env.env
+
+
+def test_set_dict_none_unsets_existing_value():
+    env = envex.Env({"var1": "value", "var2": "keep"}, environ={})
+
+    env.set({"var1": None, "var2": 123})
+
+    assert "var1" not in env.env
+    assert env.env["var2"] == "123"
 
 
 def test_setdefault_exists():


### PR DESCRIPTION
## Summary
- Keep `.env` `export` writes isolated to the supplied environment mapping unless `load_env(update=True)` updates `os.environ`.
- Treat `Env.set(..., None)` as unset semantics and make `setdefault(..., None)` avoid storing `None` while preserving existing values.
- Replace the deprecated `testcontainers.vault.VaultContainer` import with a local test Vault container using `HttpWaitStrategy`, so pytest works under `-Werror`.
- Update README badges and document `set(..., None)` unset behavior.

Linear: [UT-187](https://linear.app/uniquode/issue/UT-187/fix-environment-isolation-and-none-storage-in-env-apis)