### PR TITLE
Fix Vault client KV v2 handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,15 @@
 - To migrate existing files, decrypt the legacy `.env.enc` file with a version that can read it, then re-encrypt it with envex 5.0.0 or later using
   - `envcrypt --decrypt --legacy ...`, followed by
   - `envcrypt --encrypt ...`.
+- ⚠️ BREAKING CHANGE ⚠️: `SecretsManager.base_path` and `SecretsManager.path()` now represent logical KV v2 secret paths instead of raw Vault API paths such as `secret/data/...`. Direct `SecretsManager` users that passed or compared raw API paths should migrate to logical paths and use `mount_point` for the Vault secrets engine mount, which defaults to `secret/`.
+- Vault secret reads, writes, and deletes now use hvac's KV v2 API instead of raw `client.read()`, `client.write()`, and `client.delete()` calls. This improves behavior with namespaces and non-standard mount points.
+- `SecretsManager` Vault initialization failures are now instance-local; one transient failure no longer disables Vault lookups for all later instances in the process.
+- Vault client certificate environment handling now validates PEM files and passes file paths to hvac/requests. `VAULT_CLIENT_CERT` may point to a combined certificate/key PEM file, or `VAULT_CLIENT_CERT` and `VAULT_CLIENT_KEY` may point to separate files. Incomplete client certificate configuration now logs a warning.
+- `SecretsManager.set_secrets(path, values={})` is non-destructive; use `delete_secrets(path)` to delete a secret document explicitly.
+- `.env` `export` lines no longer bypass isolated environment mappings by writing directly to `os.environ`; global process updates remain controlled by `load_env(update=True)` or explicit `Env.export()`.
+- `Env.set(..., None)` now treats `None` as unset, and `Env.setdefault(..., None)` no longer stores `None`. Dict arguments passed to `Env(...)` use the same setter semantics, so `None` is not stringified as `"None"`.
+- Test Vault container setup now avoids deprecated `testcontainers.vault.VaultContainer` imports, keeping warning-as-error test collection clean.
+- Documentation now uses the official HashiCorp Vault capitalization.
 
 ### v4.4.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 - ⚠️ BREAKING CHANGE ⚠️: `SecretsManager.base_path` and `SecretsManager.path()` now represent logical KV v2 secret paths instead of raw Vault API paths such as `secret/data/...`. Direct `SecretsManager` users that passed or compared raw API paths should migrate to logical paths and use `mount_point` for the Vault secrets engine mount, which defaults to `secret/`.
 - Vault secret reads, writes, and deletes now use hvac's KV v2 API instead of raw `client.read()`, `client.write()`, and `client.delete()` calls. This improves behavior with namespaces and non-standard mount points.
 - `SecretsManager` Vault initialization failures are now instance-local; one transient failure no longer disables Vault lookups for all later instances in the process.
+- The optional Vault integration remains importable when `hvac` is not installed.
 - Vault client certificate environment handling now validates PEM files and passes file paths to hvac/requests. `VAULT_CLIENT_CERT` may point to a combined certificate/key PEM file, or `VAULT_CLIENT_CERT` and `VAULT_CLIENT_KEY` may point to separate files. Incomplete client certificate configuration now logs a warning.
 - `SecretsManager.set_secrets(path, values={})` is non-destructive; use `delete_secrets(path)` to delete a secret document explicitly.
 - `.env` `export` lines no longer bypass isolated environment mappings by writing directly to `os.environ`; global process updates remain controlled by `load_env(update=True)` or explicit `Env.export()`.

--- a/README.md
+++ b/README.md
@@ -112,9 +112,10 @@ In addition, Env supports a few HashiCorp Vault configuration parameters as well
 * token: (str, optional) vault token, default is `$VAULT_TOKEN` or content of `~/.vault-token`
 * cert: (tuple, optional) (cert, key) path to client SSL certificate and key files
 * verify: (bool, optional) whether to verify server cert (default is True)
-* base_path: (optional) secrets base path, or "environment" for secrets (default is None).
+* base_path: (optional) logical secrets base path, or "environment" for secrets (default is None).
+* mount_point: (optional) Vault secrets engine mount point (default is `secret/`).
 * enable_cache: bool whether to cache values fetched from Vault (default is True)
-  This is used to prefix the path to the secret, i.e. `f"/secret/{base_path}/key"`.
+  This is used to prefix the logical path to the secret, i.e. `f"{base_path}/key"`.
 
 Some type-smart functions act as an alternative to `Env.get` and having to parse the result:
 ```python
@@ -251,7 +252,7 @@ A read-only profile is the strongly recommended policy for tokens used at runtim
 
 This library provides a utility called `env2hvac` that can import (create or update) a typical .env file into vault. The
 utility uses a prefix that consists of an application name and an environment name, using the format <appname>/<envname>/<key> - for example, myapp/prod/DB_PASSWORD. The utility requires that the token has a role with create permission for the base secrets path on the vault server.
-The utility currently assumes that the kv secrets engine is mounted at secret/. The final path where the secrets are stored will be secret/data/<appname>/<envname>/<key>.
+By default, the utility uses the kv.v2 secrets engine mounted at `secret/`. The logical path where the secrets are stored will be <appname>/<envname>/<key>.
 
 ### Environment Variables
 

--- a/README.md
+++ b/README.md
@@ -110,10 +110,10 @@ In addition, Env supports a few HashiCorp Vault configuration parameters as well
 
 * url: (str, optional) vault url, default is `$VAULT_ADDR`
 * token: (str, optional) vault token, default is `$VAULT_TOKEN` or content of `~/.vault-token`
-* cert: (tuple, optional) (cert, key) path to client SSL certificate and key files
+* cert: (str or tuple, optional) path to a combined client certificate/key PEM file, or a `(cert, key)` tuple of separate PEM file paths
 * verify: (bool, optional) whether to verify server cert (default is True)
 * base_path: (optional) logical secrets base path, or "environment" for secrets (default is None).
-* mount_point: (optional) Vault secrets engine mount point (default is `secret/`).
+* mount_point: (optional) Vault secrets engine mount point (default is `secret/`; values may be provided with or without slashes and are normalized internally).
 * enable_cache: bool whether to cache values fetched from Vault (default is True)
   This is used to prefix the logical path to the secret, i.e. `f"{base_path}/key"`.
 
@@ -251,8 +251,8 @@ To access the Vault server, you need a token with a role that has read permissio
 A read-only profile is the strongly recommended policy for tokens used at runtime by the application.
 
 This library provides a utility called `env2hvac` that can import (create or update) a typical .env file into vault. The
-utility uses a prefix that consists of an application name and an environment name, using the format <appname>/<envname>/<key> - for example, myapp/prod/DB_PASSWORD. The utility requires that the token has a role with create permission for the base secrets path on the vault server.
-By default, the utility uses the kv.v2 secrets engine mounted at `secret/`. The logical path where the secrets are stored will be <appname>/<envname>/<key>.
+utility stores one KV document per application and environment, using the logical path <appname>/<envname> - for example, myapp/prod - with .env keys stored inside that document. The utility requires that the token has a role with create or update permission for the target secrets path on the vault server.
+By default, the utility uses the kv.v2 secrets engine mounted at `secret/`. A key such as `DB_PASSWORD` from `myapp/prod` is stored inside the KV document at logical path `myapp/prod`.
 
 ### Environment Variables
 
@@ -267,5 +267,5 @@ A summary of these variables is in the following table:
 | VAULT_TOKEN       | The vault token to use for authentication                              |
 | VAULT_CACERT      | The path to the CA certificate to use for TLS verification             |
 | VAULT_CAPATH      | The path to a directory of CA certificates to use for TLS verification |
-| VAULT_CLIENT_CERT | The path to the client certificate to use for TLS connection           |
-| VAULT_CLIENT_KEY  | The path to the client key to use for TLS connection                   |
+| VAULT_CLIENT_CERT | The path to the client certificate PEM file, or a combined certificate/key PEM file for TLS client auth |
+| VAULT_CLIENT_KEY  | The optional path to a separate client key PEM file for TLS client auth |

--- a/envex/env_hvac.py
+++ b/envex/env_hvac.py
@@ -1,13 +1,22 @@
 # -*- coding: utf-8 -*-
 """
-This optional module is used to interface envex with the hvac (Hashicorp Vault) library.
+This optional module is used to interface envex with the hvac (HashiCorp Vault) library.
 """
 
 import logging
 import os
 from typing import Any, Iterator
 
+from hvac.exceptions import InvalidPath
+
 __all__ = ("SecretsManager",)
+
+
+def _pem_file_contains(path: str | None, marker: str) -> bool:
+    if path is None or not os.path.isfile(path):
+        return False
+    with open(path, "r") as f:
+        return marker in f.read()
 
 
 def expand(path: str):
@@ -16,26 +25,21 @@ def expand(path: str):
 
 def read_pem(variable: str, is_key: bool = False):
     """
-    Get the value of the given environment variable and return it as a PEM string.
+    Get the path from the given environment variable if it points to a valid PEM file.
 
     @param variable: The name of the environment variable to retrieve.
     @param is_key: Whether the file is a cert key or not
-    @returns: The PEM string value of the environment variable if it looks valid.
+    @returns: The expanded file path if it looks valid.
     """
     value = os.getenv(variable)
     if value is not None:
         value = expand(value)
-        if os.path.isfile(value):
-            with open(value, "r") as f:
-                value = f.read()
-                intro = "PRIVATE KEY" if is_key else "BEGIN CERTIFICATE"
-                value = value if intro in value else None
+        intro = "PRIVATE KEY" if is_key else "BEGIN CERTIFICATE"
+        value = value if _pem_file_contains(value, intro) else None
     return value
 
 
 class SecretsManager:
-    hvac_disabled = False
-
     def __init__(
         self,
         url: str | None = None,
@@ -72,50 +76,58 @@ class SecretsManager:
         if isinstance(verify, str):
             verify = expand(verify)
         if cert is None:
-            cert = (
-                read_pem("VAULT_CLIENT_CERT", False),
-                read_pem("VAULT_CLIENT_KEY", True),
-            )
-            if cert[0] is None:
+            cert_path = read_pem("VAULT_CLIENT_CERT", False)
+            key_path = read_pem("VAULT_CLIENT_KEY", True)
+            cert_has_key = _pem_file_contains(cert_path, "PRIVATE KEY")
+            if cert_path and key_path:
+                cert = (cert_path, key_path)
+            elif cert_path and cert_has_key:
+                cert = cert_path
+            elif cert_path or key_path:
+                logging.warning(
+                    "Ignoring incomplete Vault client certificate configuration; "
+                    "VAULT_CLIENT_CERT must point to a valid PEM file containing "
+                    "both certificate and private key, or VAULT_CLIENT_CERT and "
+                    "VAULT_CLIENT_KEY must point to valid PEM files"
+                )
                 cert = None
         if base_path is None:
             base_path = os.getenv("VAULT_PATH", "")
         if not mount_point:
             mount_point = "secret"
         self._client: Any | None = None
-        if SecretsManager.hvac_disabled:
+        self.hvac_disabled = False
+        # noinspection PyBroadException
+        try:
+            import hvac
+
+            timeout = timeout or int(os.getenv("VAULT_TIMEOUT", "5"))
+
+            self._client: hvac.Client
+            self._client = hvac.Client(
+                url=url,
+                token=token,
+                cert=cert,
+                verify=verify,
+                timeout=timeout,
+                **kwargs,
+            )
+            if engine:
+                self._engine = engine.lower()
+                response = self._client.sys.list_mounted_secrets_engines()
+                for path, config in response["data"].items():
+                    if config["type"] == self._engine:
+                        mount_point = path
+                        break
+            else:
+                self._engine = None  # assume kv
+        except Exception as e:
+            msg = f"{e.__class__.__name__} secrets manager disabled: {e}"
+            logging.debug(msg)
+            self.hvac_disabled = True
             self._client = None
-        else:
-            # noinspection PyBroadException
-            try:
-                import hvac
-
-                timeout = timeout or int(os.getenv("VAULT_TIMEOUT", "5"))
-
-                self._client: hvac.Client
-                self._client = hvac.Client(
-                    url=url,
-                    token=token,
-                    cert=cert,
-                    verify=verify,
-                    timeout=timeout,
-                    **kwargs,
-                )
-                if engine:
-                    self._engine = engine.lower()
-                    response = self._client.sys.list_mounted_secrets_engines()
-                    for path, config in response["data"].items():
-                        if config["type"] == self._engine:
-                            mount_point = path
-                            break
-                else:
-                    self._engine = None  # assume kv
-            except Exception as e:
-                msg = f"{e.__class__.__name__} secrets manager disabled: {e}"
-                logging.debug(msg)
-                SecretsManager.hvac_disabled = True
-                self._client = None
-        self._base_path = self.join(mount_point, "data", base_path)
+        self._mount_point = mount_point.strip("/")
+        self._base_path = self.join(base_path)
         self._secrets = {}
 
     @staticmethod
@@ -126,8 +138,17 @@ class SecretsManager:
     def base_path(self) -> str:
         return self._base_path
 
+    @property
+    def mount_point(self) -> str:
+        return self._mount_point
+
     def path(self, key) -> str:
         return self.join(self.base_path, key)
+
+    @property
+    def kv2(self):
+        client = self.client
+        return client.secrets.kv.v2 if client else None
 
     @property
     def client(self):
@@ -146,23 +167,38 @@ class SecretsManager:
         return self._secrets
 
     def get_secrets(self, path: str = "") -> dict:
-        if self.client:
-            response = self.client.read(self.path(path))
+        kv2 = self.kv2
+        if kv2:
+            try:
+                response = kv2.read_secret_version(
+                    path=self.path(path),
+                    mount_point=self.mount_point,
+                    raise_on_deleted_version=True,
+                )
+            except InvalidPath:
+                self._secrets = {}
+                return self.secrets
             if response is not None and "data" in response:
                 self._secrets = response["data"].get("data", {})
         return self.secrets
 
     def set_secrets(self, path: str = "", values: dict | None = None):
-        if self.client and values:
+        kv2 = self.kv2
+        if kv2 and values:
             self._secrets |= values
             if self.secrets:
-                self.client.write(self.path(path), data=self.secrets)
-            else:
-                self.client.delete(self.path(path))
+                kv2.create_or_update_secret(
+                    path=self.path(path),
+                    secret=self.secrets,
+                    mount_point=self.mount_point,
+                )
 
     def delete_secrets(self, path: str = "") -> None:
-        if self.client:
-            self.client.delete(self.path(path))
+        kv2 = self.kv2
+        if kv2:
+            kv2.delete_metadata_and_all_versions(
+                path=self.path(path), mount_point=self.mount_point
+            )
         self._secrets.clear()
 
     def get_secret(self, key: str, default: str | None = None, error: bool = False):
@@ -178,22 +214,34 @@ class SecretsManager:
         return default
 
     def set_secret(self, key: str, value: str):
-        if self.client and not any((key is None, value is None)):
+        kv2 = self.kv2
+        if kv2 and not any((key is None, value is None)):
             if not self.secrets:
                 self.get_secrets()
             self.secrets[key] = value
-            self.client.write_data(self.path(""), data=dict(data=self.secrets))
+            kv2.create_or_update_secret(
+                path=self.path(""),
+                secret=dict(self.secrets),
+                mount_point=self.mount_point,
+            )
 
     def delete_secret(self, key: str, path: str = "") -> None:
-        if self.client:
+        kv2 = self.kv2
+        if kv2:
             if not self.secrets:
                 self.get_secrets()
             if self.secrets and key in self.secrets:
                 del self.secrets[key]
                 if self.secrets:
-                    self.client.write_data(self.path(path), data=dict(data=self.secrets))
+                    kv2.create_or_update_secret(
+                        path=self.path(path),
+                        secret=dict(self.secrets),
+                        mount_point=self.mount_point,
+                    )
                 else:
-                    self.client.delete(self.path(path))
+                    kv2.delete_metadata_and_all_versions(
+                        path=self.path(path), mount_point=self.mount_point
+                    )
                     self.secrets.clear()
 
     def list_secrets(self, path: str = "") -> Iterator[str]:

--- a/envex/env_hvac.py
+++ b/envex/env_hvac.py
@@ -7,9 +7,15 @@ import logging
 import os
 from typing import Any, Iterator
 
-from hvac.exceptions import InvalidPath
-
 __all__ = ("SecretsManager",)
+
+
+def _is_invalid_path(exc: Exception) -> bool:
+    try:
+        from hvac.exceptions import InvalidPath
+    except ImportError:
+        return False
+    return isinstance(exc, InvalidPath)
 
 
 def _pem_file_contains(path: str | None, marker: str) -> bool:
@@ -175,7 +181,9 @@ class SecretsManager:
                     mount_point=self.mount_point,
                     raise_on_deleted_version=True,
                 )
-            except InvalidPath:
+            except Exception as exc:
+                if not _is_invalid_path(exc):
+                    raise
                 self._secrets = {}
                 return self.secrets
             if response is not None and "data" in response:

--- a/tests/test_env_hvac.py
+++ b/tests/test_env_hvac.py
@@ -1,285 +1,343 @@
 # -*- coding: utf-8 -*-
-from unittest.mock import MagicMock, patch
+from types import SimpleNamespace
 
+import hvac
 import pytest
+from hvac.exceptions import InvalidPath
 
-from envex.env_hvac import SecretsManager
+from envex.env_hvac import SecretsManager, read_pem
 
-# Constants for testing
 BASE_URL = "http://vault.example.com:8200"
 TOKEN = "s.1234567890abcdef"
 CERT = ("path/to/cert.pem", "path/to/key.pem")
-VERIFY = True
 BASE_PATH = "base/path"
-ENGINE = "kv"
-MOUNT_POINT = "secret"
 
 
-@pytest.fixture
-def mock_init_client():
-    # Mock the hvac.Client class
-    class MockClient:
-        def __init__(self, *args, **kwargs):
-            self.authenticated = True
-            self.secrets = {}
-            self.seal_status = {"sealed": False}
+class FakeKvV2:
+    def __init__(self, initial=None):
+        self.store = dict(initial or {})
+        self.read_calls = []
+        self.write_calls = []
+        self.delete_calls = []
 
-        def is_authenticated(self):
-            return self.authenticated
+    def read_secret_version(self, path, version=None, mount_point="secret", **kwargs):
+        self.read_calls.append(
+            {
+                "path": path,
+                "version": version,
+                "mount_point": mount_point,
+                "kwargs": kwargs,
+            }
+        )
+        secret = self.store.get((mount_point, path))
+        return {"data": {"data": dict(secret)}} if secret is not None else {}
 
-        def read(self, path):
-            return {"data": {"data": self.secrets.get(path)}}
+    def create_or_update_secret(self, path, secret, cas=None, mount_point="secret"):
+        self.write_calls.append(
+            {
+                "path": path,
+                "secret": dict(secret),
+                "cas": cas,
+                "mount_point": mount_point,
+            }
+        )
+        self.store[(mount_point, path)] = dict(secret)
 
-        def write(self, path, **kwargs):
-            self.secrets[path] = kwargs
-
-        def delete(self, path):
-            self.secrets.pop(path, None)
-
-        def sys(self):
-            return MagicMock(
-                list_mounted_secrets_engines=MagicMock(return_value={"data": {}})
-            )
-
-    with patch("hvac.Client", new=MockClient):
-        yield MockClient()
-
-
-test_params = [
-    # ID: Happy-Path-1
-    (
-        BASE_URL,
-        TOKEN,
-        CERT,
-        VERIFY,
-        BASE_PATH,
-        ENGINE,
-        MOUNT_POINT,
-        SecretsManager.join(MOUNT_POINT, "data", BASE_PATH),
-    ),
-    # ID: Happy-Path-2
-    (
-        BASE_URL,
-        TOKEN,
-        None,
-        VERIFY,
-        None,
-        None,
-        None,
-        SecretsManager.join("secret", "data"),
-    ),
-    # ID: Edge-Case-1
-    (
-        BASE_URL,
-        TOKEN,
-        CERT,
-        "/path/to/ca.pem",
-        BASE_PATH,
-        ENGINE,
-        MOUNT_POINT,
-        SecretsManager.join(MOUNT_POINT, "data", BASE_PATH),
-    ),
-    # ID: Error-Case-1
-    (
-        None,
-        None,
-        None,
-        VERIFY,
-        BASE_PATH,
-        ENGINE,
-        MOUNT_POINT,
-        SecretsManager.join(MOUNT_POINT, "data", BASE_PATH),
-    ),
-]
+    def delete_metadata_and_all_versions(self, path, mount_point="secret"):
+        self.delete_calls.append({"path": path, "mount_point": mount_point})
+        self.store.pop((mount_point, path), None)
 
 
-@pytest.mark.vault
+class FakeClient:
+    def __init__(self, kv2=None, mounts=None, authenticated=True):
+        self.authenticated = authenticated
+        self.seal_status = {"sealed": False}
+        self.secrets = SimpleNamespace(kv=SimpleNamespace(v2=kv2 or FakeKvV2()))
+        self._mounts = mounts or {"secret/": {"type": "kv"}}
+
+    def is_authenticated(self):
+        return self.authenticated
+
+    @property
+    def sys(self):
+        return SimpleNamespace(
+            list_mounted_secrets_engines=lambda: {"data": self._mounts},
+            seal=self._seal,
+            submit_unseal_keys=self._submit_unseal_keys,
+        )
+
+    def _seal(self):
+        self.seal_status["sealed"] = True
+        return self.seal_status
+
+    def _submit_unseal_keys(self, keys, root_token):
+        self.seal_status["sealed"] = False
+        return self.seal_status
+
+
+def make_manager(base_path="", mount_point="secret", kv2=None):
+    manager = SecretsManager.__new__(SecretsManager)
+    manager._client = FakeClient(kv2=kv2)
+    manager.hvac_disabled = False
+    manager._engine = None
+    manager._mount_point = mount_point
+    manager._base_path = SecretsManager.join(base_path)
+    manager._secrets = {}
+    return manager
+
+
+def install_fake_hvac_client(monkeypatch, mounts=None):
+    instances = []
+
+    class InitClient(FakeClient):
+        def __init__(self, **kwargs):
+            self.kwargs = kwargs
+            instances.append(self)
+            super().__init__(mounts=mounts)
+
+    monkeypatch.setattr(hvac, "Client", InitClient)
+    return instances
+
+
 @pytest.mark.parametrize(
-    "url, token, cert, verify, base_path, engine, mount_point, expected_base_path",
-    test_params,
+    ("base_path", "engine", "mount_point", "mounts", "expected_base", "expected_mount"),
+    [
+        (BASE_PATH, None, "secret", None, BASE_PATH, "secret"),
+        (None, None, None, None, "", "secret"),
+        (
+            BASE_PATH,
+            "kv",
+            None,
+            {"custom/": {"type": "kv"}},
+            BASE_PATH,
+            "custom",
+        ),
+    ],
 )
-def test_secrets_manager_initialization(
-    url,
-    token,
-    cert,
-    verify,
+def test_secrets_manager_initialization_uses_logical_paths(
     base_path,
     engine,
     mount_point,
-    expected_base_path,
-    mock_init_client,
+    mounts,
+    expected_base,
+    expected_mount,
+    monkeypatch,
 ):
-    # Arrange
-    with patch("envex.env_hvac.os.getenv", side_effect=lambda k, v=None: v):
-        with patch("envex.env_hvac.expand", side_effect=lambda v: v):
-            with patch("envex.env_hvac.read_pem", side_effect=lambda k, req: None):
-                # Act
-                manager = SecretsManager(
-                    url=url,
-                    token=token,
-                    cert=cert,
-                    verify=verify,
-                    base_path=base_path,
-                    engine=engine,
-                    mount_point=mount_point,
-                )
+    monkeypatch.delenv("VAULT_PATH", raising=False)
+    instances = install_fake_hvac_client(monkeypatch, mounts=mounts)
 
-                # Assert
-                assert manager.base_path == expected_base_path
+    manager = SecretsManager(
+        url=BASE_URL,
+        token=TOKEN,
+        cert=CERT,
+        verify=True,
+        base_path=base_path,
+        engine=engine,
+        mount_point=mount_point,
+    )
 
-
-# Fixture to create a mock client and attach it to the object under test
-@pytest.fixture
-def secrets_manager():
-    # Mock class to simulate the client's behaviour
-    class MockClient:
-        seal_status = {"sealed": False}
-
-        def read(self, path):
-            mock_responses = {
-                "secret/data/valid/path": {
-                    "data": {"data": {"secret_key": "secret_value"}}
-                },
-                "secret/data/valid/empty": {"data": {"data": {}}},
-                "secret/data/no/data": {},
-                None: None,
-            }
-            return mock_responses.get(path)
-
-        def write(self, path, **kwargs):
-            pass
-
-        def write_data(self, path, **kwargs):
-            pass
-
-        def delete(self, path):
-            pass
-
-        @property
-        def sys(self):
-            class Sys:
-                def seal(self):
-                    MockClient.seal_status["sealed"] = True
-                    return MockClient.seal_status
-
-                def unseal(self, keys, root_token):
-                    MockClient.seal_status["sealed"] = False
-                    return MockClient.seal_status
-
-                def submit_unseal_keys(self, keys, root_token):
-                    MockClient.seal_status["sealed"] = False
-                    return MockClient.seal_status
-
-            return Sys()
-
-    class SecretsManagerEx(SecretsManager):
-        def __init__(self):
-            super().__init__()
-            self._client = None
-
-        @property
-        def client(self):
-            if not self._client:
-                self._client = MockClient()
-            return self._client
-
-    return SecretsManagerEx()
+    assert instances[0].kwargs["cert"] == CERT
+    assert manager.base_path == expected_base
+    assert manager.mount_point == expected_mount
+    assert manager.path("app/prod") == SecretsManager.join(expected_base, "app/prod")
 
 
-# Parametrized test cases
-@pytest.mark.vault
+def test_initialization_failure_is_instance_local(monkeypatch):
+    calls = 0
+
+    def fake_client(**kwargs):
+        nonlocal calls
+        calls += 1
+        if calls == 1:
+            raise RuntimeError("temporary import/auth setup failure")
+        return FakeClient()
+
+    monkeypatch.setattr(hvac, "Client", fake_client)
+
+    failed = SecretsManager()
+    working = SecretsManager()
+
+    assert failed.hvac_disabled
+    assert failed.client is None
+    assert not working.hvac_disabled
+    assert working.client is working._client
+
+
 @pytest.mark.parametrize(
-    "test_input, test_input_key, expected_output, test_id",
+    ("env_name", "contents", "is_key"),
     [
-        # Happy path tests with various realistic test values
-        (
-            "valid/path",
-            "secret_key",
-            {"secret_key": "secret_value"},
-            "happy_path_valid_data",
-        ),
-        ("valid/empty", "secret_key", {}, "happy_path_empty_data"),
-        # Edge cases
-        ("", "", {}, "edge_case_no_path"),
-        ("no/data", "", {}, "edge_case_no_data_in_response"),
-        # Error cases
-        (None, None, {}, "error_case_none_path"),
+        ("VAULT_CLIENT_CERT", "-----BEGIN CERTIFICATE-----\n", False),
+        ("VAULT_CLIENT_KEY", "-----BEGIN PRIVATE KEY-----\n", True),
     ],
 )
-def test_get_secrets(
-    secrets_manager, test_input, test_input_key, expected_output, test_id
+def test_read_pem_returns_valid_file_path(
+    tmp_path, monkeypatch, env_name, contents, is_key
 ):
-    # Act
-    result = secrets_manager.get_secrets(test_input)
+    pem_file = tmp_path / f"{env_name}.pem"
+    pem_file.write_text(contents)
+    monkeypatch.setenv(env_name, pem_file.as_posix())
 
-    # Assert
-    assert result == expected_output, (
-        f"get_secrets({test_input}) failed for test_id: {test_id}"
-    )
-
-    # Act
-    result = secrets_manager.get_secret(test_input_key)
-
-    # Assert
-    assert result == expected_output.get(test_input_key, None), (
-        f"get_secret({test_input_key}) failed for test_id: {test_id}"
-    )
-
-    # Act
-    secrets_manager.delete_secrets(test_input)
-
-    assert secrets_manager.secrets == {}
+    assert read_pem(env_name, is_key=is_key) == pem_file.as_posix()
 
 
-@pytest.mark.vault
-@pytest.mark.parametrize(
-    "test_input_key, expected_inital_output, modified_value, test_id",
-    [
-        # Happy path tests with various test values
-        (
-            "not_a_secret_key",
-            None,
-            "new_value",
-            "happy_path_valid_data",
-        ),
-        ("secret_key", None, None, "happy_path_empty_data"),
-        # Edge cases
-        ("", None, None, "edge_case_no_path"),
-        ("", None, None, "edge_case_no_data_in_response"),
-        # Error cases
-        (None, None, None, "error_case_none_path"),
-    ],
-)
-def test_get_set_secret(
-    secrets_manager, test_input_key, expected_inital_output, modified_value, test_id
+def test_read_pem_rejects_inline_or_invalid_pem(tmp_path, monkeypatch):
+    pem_file = tmp_path / "invalid.pem"
+    pem_file.write_text("not a certificate")
+    monkeypatch.setenv("INLINE_PEM", "-----BEGIN CERTIFICATE-----\n")
+    monkeypatch.setenv("INVALID_PEM", pem_file.as_posix())
+
+    assert read_pem("INLINE_PEM") is None
+    assert read_pem("INVALID_PEM") is None
+
+
+def test_client_certificate_env_vars_are_passed_as_paths(tmp_path, monkeypatch):
+    cert = tmp_path / "client.pem"
+    key = tmp_path / "client-key.pem"
+    cert.write_text("-----BEGIN CERTIFICATE-----\n")
+    key.write_text("-----BEGIN PRIVATE KEY-----\n")
+    monkeypatch.setenv("VAULT_CLIENT_CERT", cert.as_posix())
+    monkeypatch.setenv("VAULT_CLIENT_KEY", key.as_posix())
+    instances = install_fake_hvac_client(monkeypatch)
+
+    SecretsManager()
+
+    assert instances[0].kwargs["cert"] == (cert.as_posix(), key.as_posix())
+
+
+def test_combined_client_certificate_file_is_passed_as_single_path(
+    tmp_path, monkeypatch, caplog
 ):
-    result = secrets_manager.get_secret(test_input_key)
-    assert result == expected_inital_output, (
-        f"get_secret({test_input_key}) failed for test_id: {test_id}"
-    )
+    cert = tmp_path / "client-combined.pem"
+    cert.write_text("-----BEGIN CERTIFICATE-----\n-----BEGIN PRIVATE KEY-----\n")
+    monkeypatch.setenv("VAULT_CLIENT_CERT", cert.as_posix())
+    monkeypatch.delenv("VAULT_CLIENT_KEY", raising=False)
+    instances = install_fake_hvac_client(monkeypatch)
 
-    secrets_manager.set_secret(test_input_key, modified_value)
-    result = secrets_manager.get_secret(test_input_key)
-    assert result == modified_value, (
-        f"get_secret({test_input_key}) failed for test_id: {test_id}"
-    )
+    SecretsManager()
 
-    result = list(secrets_manager.list_secrets())
-    expected_result = [test_input_key] if modified_value else []
-    assert result == expected_result, f"list_secrets() failed for test_id: {test_id}"
-
-    secrets_manager.delete_secret(test_input_key)
-    assert secrets_manager.secrets == {}, (
-        f"delete_secret({test_input_key}) failed for test_id: {test_id}"
-    )
-
-    result = list(secrets_manager.list_secrets())
-    assert not result
+    assert instances[0].kwargs["cert"] == cert.as_posix()
+    assert "Ignoring incomplete Vault client certificate configuration" not in caplog.text
 
 
-@pytest.mark.vault
-def test_seal_unseal(secrets_manager):
-    secrets_manager.seal()
-    assert secrets_manager.sealed
-    secrets_manager.unseal(None, None)
-    assert not secrets_manager.sealed
+def test_client_certificate_env_vars_require_cert_and_key(tmp_path, monkeypatch, caplog):
+    cert = tmp_path / "client.pem"
+    cert.write_text("-----BEGIN CERTIFICATE-----\n")
+    monkeypatch.setenv("VAULT_CLIENT_CERT", cert.as_posix())
+    monkeypatch.delenv("VAULT_CLIENT_KEY", raising=False)
+    instances = install_fake_hvac_client(monkeypatch)
+
+    SecretsManager()
+
+    assert instances[0].kwargs["cert"] is None
+    assert "Ignoring incomplete Vault client certificate configuration" in caplog.text
+
+
+def test_get_secrets_uses_kv_v2_read_with_mount_and_logical_path():
+    kv2 = FakeKvV2({("custom", "base/app"): {"secret_key": "secret_value"}})
+    manager = make_manager(base_path="base", mount_point="custom", kv2=kv2)
+
+    assert manager.get_secrets("app") == {"secret_key": "secret_value"}
+
+    assert kv2.read_calls == [
+        {
+            "path": "base/app",
+            "version": None,
+            "mount_point": "custom",
+            "kwargs": {"raise_on_deleted_version": True},
+        }
+    ]
+
+
+def test_get_secrets_treats_missing_kv_path_as_empty():
+    class MissingKvV2(FakeKvV2):
+        def read_secret_version(self, path, version=None, mount_point="secret", **kwargs):
+            super().read_secret_version(path, version, mount_point, **kwargs)
+            raise InvalidPath("missing secret")
+
+    kv2 = MissingKvV2()
+    manager = make_manager(kv2=kv2)
+    manager._secrets = {"OLD": "stale"}
+
+    assert manager.get_secrets("missing") == {}
+
+
+def test_set_secrets_uses_kv_v2_write_with_mount_and_logical_path():
+    kv2 = FakeKvV2()
+    manager = make_manager(base_path="base", mount_point="custom", kv2=kv2)
+    manager._secrets = {"EXISTING": "keep"}
+
+    manager.set_secrets("app", values={"PUBLIC": "hello"})
+
+    assert kv2.write_calls == [
+        {
+            "path": "base/app",
+            "secret": {"EXISTING": "keep", "PUBLIC": "hello"},
+            "cas": None,
+            "mount_point": "custom",
+        }
+    ]
+
+
+def test_set_secrets_with_empty_values_is_not_destructive():
+    kv2 = FakeKvV2({("secret", "base/app"): {"PUBLIC": "hello"}})
+    manager = make_manager(base_path="base", kv2=kv2)
+    manager._secrets = {}
+
+    manager.set_secrets("app", values={})
+
+    assert kv2.write_calls == []
+    assert kv2.delete_calls == []
+    assert kv2.store == {("secret", "base/app"): {"PUBLIC": "hello"}}
+
+
+def test_delete_secrets_uses_kv_v2_metadata_delete():
+    kv2 = FakeKvV2({("secret", "base/app"): {"PUBLIC": "hello"}})
+    manager = make_manager(base_path="base", kv2=kv2)
+    manager._secrets = {"PUBLIC": "hello"}
+
+    manager.delete_secrets("app")
+
+    assert kv2.delete_calls == [{"path": "base/app", "mount_point": "secret"}]
+    assert manager.secrets == {}
+
+
+def test_get_set_list_and_delete_secret():
+    kv2 = FakeKvV2({("secret", "base"): {"ABC": "123", "DEF": "456"}})
+    manager = make_manager(base_path="base", kv2=kv2)
+
+    assert manager.get_secret("ABC") == "123"
+
+    manager.set_secret("XYZ", "789")
+    assert manager.get_secret("XYZ") == "789"
+    assert list(manager.list_secrets()) == ["ABC", "DEF", "XYZ"]
+    assert kv2.write_calls[-1] == {
+        "path": "base",
+        "secret": {"ABC": "123", "DEF": "456", "XYZ": "789"},
+        "cas": None,
+        "mount_point": "secret",
+    }
+
+    manager.delete_secret("XYZ")
+    assert "XYZ" not in manager.secrets
+    assert kv2.write_calls[-1]["secret"] == {"ABC": "123", "DEF": "456"}
+
+
+def test_delete_secret_removes_empty_vault_document():
+    kv2 = FakeKvV2({("secret", "base"): {"ABC": "123"}})
+    manager = make_manager(base_path="base", kv2=kv2)
+
+    assert manager.get_secret("ABC") == "123"
+
+    manager.delete_secret("ABC")
+
+    assert manager.secrets == {}
+    assert kv2.delete_calls == [{"path": "base", "mount_point": "secret"}]
+
+
+def test_seal_unseal():
+    manager = make_manager()
+
+    manager.seal()
+    assert manager.sealed
+    manager.unseal([], None)
+    assert not manager.sealed

--- a/tests/test_env_hvac.py
+++ b/tests/test_env_hvac.py
@@ -167,7 +167,7 @@ def test_initialization_failure_is_instance_local(monkeypatch):
     ("env_name", "contents", "is_key"),
     [
         ("VAULT_CLIENT_CERT", "-----BEGIN CERTIFICATE-----\n", False),
-        ("VAULT_CLIENT_KEY", "-----BEGIN PRIVATE KEY-----\n", True),
+        ("VAULT_CLIENT_KEY", "not a real PRIVATE KEY\n", True),
     ],
 )
 def test_read_pem_returns_valid_file_path(
@@ -194,7 +194,7 @@ def test_client_certificate_env_vars_are_passed_as_paths(tmp_path, monkeypatch):
     cert = tmp_path / "client.pem"
     key = tmp_path / "client-key.pem"
     cert.write_text("-----BEGIN CERTIFICATE-----\n")
-    key.write_text("-----BEGIN PRIVATE KEY-----\n")
+    key.write_text("not a real PRIVATE KEY\n")
     monkeypatch.setenv("VAULT_CLIENT_CERT", cert.as_posix())
     monkeypatch.setenv("VAULT_CLIENT_KEY", key.as_posix())
     instances = install_fake_hvac_client(monkeypatch)
@@ -208,7 +208,7 @@ def test_combined_client_certificate_file_is_passed_as_single_path(
     tmp_path, monkeypatch, caplog
 ):
     cert = tmp_path / "client-combined.pem"
-    cert.write_text("-----BEGIN CERTIFICATE-----\n-----BEGIN PRIVATE KEY-----\n")
+    cert.write_text("-----BEGIN CERTIFICATE-----\nnot a real PRIVATE KEY\n")
     monkeypatch.setenv("VAULT_CLIENT_CERT", cert.as_posix())
     monkeypatch.delenv("VAULT_CLIENT_KEY", raising=False)
     instances = install_fake_hvac_client(monkeypatch)


### PR DESCRIPTION
Summary
- Switch SecretsManager path handling to logical KV v2 paths plus mount_point.
- Use hvac KV v2 APIs for Vault read, write, and delete operations, with instance-local initialization failures.
- Validate Vault client certificate env vars as PEM file paths, including combined cert/key files, and document the v5.0.0 behavior changes.

Linear: [UT-188](https://linear.app/uniquode/issue/UT-188/fix-vault-client-state-cert-paths-and-kv-api-writes)