### PR TITLE
Fix Env parsing and default discovery

### DIFF
--- a/.idea/envex.iml
+++ b/.idea/envex.iml
@@ -4,7 +4,7 @@
     <content url="file://$MODULE_DIR$">
       <excludeFolder url="file://$MODULE_DIR$/.venv" />
     </content>
-    <orderEntry type="jdk" jdkName="uv (envex)" jdkType="Python SDK" />
+    <orderEntry type="inheritedJdk" />
     <orderEntry type="sourceFolder" forTests="false" />
   </component>
   <component name="PyDocumentationSettings">

--- a/.idea/envex.iml
+++ b/.idea/envex.iml
@@ -1,8 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <module type="PYTHON_MODULE" version="4">
   <component name="NewModuleRootManager">
-    <content url="file://$MODULE_DIR$" />
-    <orderEntry type="jdk" jdkName="Python 3.13 virtualenv at ~/.config/venvs/envex-65054036" jdkType="Python SDK" />
+    <content url="file://$MODULE_DIR$">
+      <excludeFolder url="file://$MODULE_DIR$/.venv" />
+    </content>
+    <orderEntry type="jdk" jdkName="uv (envex)" jdkType="Python SDK" />
     <orderEntry type="sourceFolder" forTests="false" />
   </component>
   <component name="PyDocumentationSettings">

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,6 @@
+# Agent Instructions
+
+- Read `.todo/context.md` before starting repo work; it contains the current project-specific workflow, PR, Linear, and git conventions.
+- Update `.todo/context.md` at the conclusion of each work iteration so the next handoff has current status and decisions.
+- Use `.todo/` for working notes, temporary plans, review handoffs, and other short-lived coordination documents.
+- Do not include temporary `.todo/` working documents in normal commits unless explicitly asked.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,9 @@
 - `SecretsManager.set_secrets(path, values={})` is non-destructive; use `delete_secrets(path)` to delete a secret document explicitly.
 - `.env` `export` lines no longer bypass isolated environment mappings by writing directly to `os.environ`; global process updates remain controlled by `load_env(update=True)` or explicit `Env.export()`.
 - `Env.set(..., None)` now treats `None` as unset, and `Env.setdefault(..., None)` no longer stores `None`. Dict arguments passed to `Env(...)` use the same setter semantics, so `None` is not stringified as `"None"`.
+- `Env.int()` now parses signed integer strings correctly and raises `ValueError` for malformed non-empty integer values instead of silently returning `0`.
+- `Env(...)` now separates recognized loader/Vault options from additional environment-variable kwargs, so keyword environment overrides behave as documented.
+- Default `.env` discovery now uses a lightweight caller-frame lookup that skips envex-internal wrapper frames instead of relying on `inspect.stack()[1]`.
 - Test Vault container setup now avoids deprecated `testcontainers.vault.VaultContainer` imports, keeping warning-as-error test collection clean.
 - Documentation now uses the official HashiCorp Vault capitalization.
 

--- a/README.md
+++ b/README.md
@@ -104,7 +104,7 @@ Other kwargs that can be passed to `Env` when created:
 * errors: bool whether to raise error on missing env_file (default is False)
 * decrypt: bool whether to support decryption of encrypted env files (default is False)
 * password: str the password, environment variable or file/path to use for decryption (see below)
-* kwargs: (keyword args, optional) additional environment variables to add/override
+* kwargs: (keyword args, optional) additional environment variables to add/override, after recognized loader and Vault options are applied
 
 In addition, Env supports a few HashiCorp Vault configuration parameters as well:
 
@@ -147,6 +147,7 @@ assert env.get('A_LIST_VALUE') == '1,"two",3,"four"'
 assert env.list('A_LIST_VALUE') == ['1', 'two', '3', 'four']
 assert env('A_LIST_VALUE', type=list) == ['1', 'two', '3', 'four']
 ```
+Integer and boolean parsing is strict: missing or empty integer values parse as `0`, but malformed non-empty integer strings raise `ValueError`.
 
 Environment variables are always stored as strings.
 This is enforced by the underlying os.environ, but also true of any provided environment, which must use the `MutableMapping[str, str]` contract.

--- a/envex/dot_env.py
+++ b/envex/dot_env.py
@@ -35,6 +35,7 @@ DEFAULT_ENCODING = "utf-8"
 _MODIFIER_PATTERN = re.compile(r":([-+])")
 _VAR_BRACES_PATTERN = re.compile(r"\${([^{}]+)}")
 _VAR_NO_BRACES_PATTERN = re.compile(r"\$([a-zA-Z_][a-zA-Z0-9_]*)")
+_PACKAGE_ROOT = Path(__file__).resolve().parent
 
 
 def unquote(line, quotes="\"'"):
@@ -288,6 +289,33 @@ def _update_os_env(environ: MutableMapping[str, str]) -> MutableMapping[str, str
     return os.environ
 
 
+def _is_envex_frame(filename: str) -> bool:
+    try:
+        return Path(filename).resolve().is_relative_to(_PACKAGE_ROOT)
+    except (OSError, RuntimeError, ValueError):
+        return False
+
+
+def _default_search_path() -> list[str]:
+    import inspect
+
+    frame = inspect.currentframe()
+    try:
+        frame = frame.f_back if frame else None
+        while frame:
+            filename = frame.f_code.co_filename
+            if (
+                filename
+                and not filename.startswith("<")
+                and not _is_envex_frame(filename)
+            ):
+                return [".", filename]
+            frame = frame.f_back
+        return ["."]
+    finally:
+        del frame
+
+
 def load_env(
     env_file: str | Path | None = None,
     search_path: Union[None, Union[List[str], List[Path]], str] = None,
@@ -328,10 +356,7 @@ def load_env(
 
     # determine where to search
     if search_path is None:
-        import inspect
-
-        frame = inspect.stack()[1]
-        search_path = [".", frame.filename]
+        search_path = _default_search_path()
     elif isinstance(search_path, Path):
         search_path = [search_path]
     elif isinstance(search_path, (str, bytes)):

--- a/envex/env_wrapper.py
+++ b/envex/env_wrapper.py
@@ -24,6 +24,20 @@ class Env:
     _BOOLEAN_TRUE_STRINGS = frozenset(("1", "en", "ok", "on", "t", "true", "y", "yes"))
     _BOOLEAN_FALSE_STRINGS = frozenset(("", "0", "f", "false", "n", "no", "off"))
     _EXCEPTION_CLS = KeyError
+    _LOAD_ENV_KWARGS = frozenset(
+        (
+            "env_file",
+            "search_path",
+            "overwrite",
+            "parents",
+            "update",
+            "errors",
+            "working_dirs",
+            "decrypt",
+            "password",
+            "encoding",
+        )
+    )
 
     def __init__(
         self,
@@ -68,6 +82,7 @@ class Env:
         @param mount_point: (optional) str vault secrets mount point (default=None, determined by engine)
         @param working_dirs: (optional) bool whether to include PWD/CWD (default=True)
             -
+        @param timeout: (optional) int timeout for requests sent to Vault.
         @param kwargs: (optional) environment variables to add/override
         """
         self._env = self.os_env() if environ is None else environ
@@ -81,19 +96,29 @@ class Env:
             elif isinstance(arg, (BytesIO, TextIOBase)):
                 streams.append(arg)
 
-        if "streams" in kwargs and isinstance(kwargs["streams"], (tuple, list)):
-            streams.extend(kwargs.pop("streams"))
+        stream_kwargs = kwargs.pop("streams", ())
+        if isinstance(stream_kwargs, (tuple, list)):
+            streams.extend(stream_kwargs)
+        elif isinstance(stream_kwargs, (BytesIO, TextIOBase)):
+            streams.append(stream_kwargs)
+
+        timeout = kwargs.pop("timeout", None)
+        load_env_kwargs = {
+            key: kwargs.pop(key) for key in list(kwargs) if key in self._LOAD_ENV_KWARGS
+        }
+
+        self.set(kwargs)
 
         password = self._resolve_password(
-            kwargs.get("password", None), kwargs.get("decrypt", None)
+            load_env_kwargs.get("password", None), load_env_kwargs.get("decrypt", None)
         )
-        kwargs["decrypt"] = bool(password)
-        kwargs["password"] = password
+        load_env_kwargs["decrypt"] = bool(password)
+        load_env_kwargs["password"] = password
 
-        kwargs.setdefault("environ", self._env)
+        load_env_kwargs.setdefault("environ", self._env)
         if readenv:
-            self.read_env(**kwargs)
-        self.read_streams(*streams, **kwargs)
+            self.read_env(**load_env_kwargs)
+        self.read_streams(*streams, **load_env_kwargs)
         self.env_source = self.env.get("ENVEX_SOURCE", "env") == "env"
         vault_verify = (
             verify
@@ -108,7 +133,7 @@ class Env:
             base_path=base_path,
             engine=engine,
             mount_point=mount_point,
-            timeout=kwargs.get("timeout", None),
+            timeout=timeout,
         )
 
     def _resolve_password_selector(self, selector: str | None) -> str | None:
@@ -312,9 +337,16 @@ class Env:
 
     @classmethod
     def _int(cls, val):
-        return (
-            val if isinstance(val, int) else int(val) if val and str.isdigit(val) else 0
-        )
+        if val is None or val == "":
+            return 0
+        if isinstance(val, bool):
+            return int(val)
+        if isinstance(val, int):
+            return val
+        try:
+            return int(val)
+        except (TypeError, ValueError) as exc:
+            raise ValueError(f"Invalid integer value: {val!r}") from exc
 
     @classmethod
     def _float(cls, val):

--- a/envex/env_wrapper.py
+++ b/envex/env_wrapper.py
@@ -4,6 +4,7 @@ Type smart wrapper around os.environ
 """
 
 import contextlib
+import inspect
 import re
 from pathlib import Path
 from io import TextIOBase, BytesIO
@@ -24,20 +25,7 @@ class Env:
     _BOOLEAN_TRUE_STRINGS = frozenset(("1", "en", "ok", "on", "t", "true", "y", "yes"))
     _BOOLEAN_FALSE_STRINGS = frozenset(("", "0", "f", "false", "n", "no", "off"))
     _EXCEPTION_CLS = KeyError
-    _LOAD_ENV_KWARGS = frozenset(
-        (
-            "env_file",
-            "search_path",
-            "overwrite",
-            "parents",
-            "update",
-            "errors",
-            "working_dirs",
-            "decrypt",
-            "password",
-            "encoding",
-        )
-    )
+    _LOAD_ENV_KWARGS = frozenset(inspect.signature(load_env).parameters)
 
     def __init__(
         self,
@@ -97,10 +85,7 @@ class Env:
                 streams.append(arg)
 
         stream_kwargs = kwargs.pop("streams", ())
-        if isinstance(stream_kwargs, (tuple, list)):
-            streams.extend(stream_kwargs)
-        elif isinstance(stream_kwargs, (BytesIO, TextIOBase)):
-            streams.append(stream_kwargs)
+        self._extend_streams(streams, stream_kwargs)
 
         timeout = kwargs.pop("timeout", None)
         load_env_kwargs = {
@@ -134,6 +119,26 @@ class Env:
             mount_point=mount_point,
             timeout=timeout,
         )
+
+    @staticmethod
+    def _is_stream(value):
+        return isinstance(value, (BytesIO, TextIOBase))
+
+    @classmethod
+    def _extend_streams(cls, streams: list, stream_values) -> None:
+        if stream_values is None:
+            return
+        if cls._is_stream(stream_values):
+            streams.append(stream_values)
+            return
+        try:
+            iterable = iter(stream_values)
+        except TypeError as exc:
+            raise TypeError("streams must be a stream or an iterable of streams") from exc
+        for stream in iterable:
+            if not cls._is_stream(stream):
+                raise TypeError("streams must contain only stream objects")
+            streams.append(stream)
 
     def _resolve_password_selector(self, selector: str | None) -> str | None:
         if not selector:

--- a/envex/env_wrapper.py
+++ b/envex/env_wrapper.py
@@ -101,6 +101,7 @@ class Env:
         load_env_kwargs.setdefault("environ", self._env)
         if readenv:
             self.read_env(**load_env_kwargs)
+            load_env_kwargs["environ"] = self._env
         self.read_streams(*streams, **load_env_kwargs)
         self.set(kwargs)
         self.env_source = self.env.get("ENVEX_SOURCE", "env") == "env"

--- a/envex/env_wrapper.py
+++ b/envex/env_wrapper.py
@@ -107,8 +107,6 @@ class Env:
             key: kwargs.pop(key) for key in list(kwargs) if key in self._LOAD_ENV_KWARGS
         }
 
-        self.set(kwargs)
-
         password = self._resolve_password(
             load_env_kwargs.get("password", None), load_env_kwargs.get("decrypt", None)
         )
@@ -119,6 +117,7 @@ class Env:
         if readenv:
             self.read_env(**load_env_kwargs)
         self.read_streams(*streams, **load_env_kwargs)
+        self.set(kwargs)
         self.env_source = self.env.get("ENVEX_SOURCE", "env") == "env"
         vault_verify = (
             verify

--- a/tests/test_load_env.py
+++ b/tests/test_load_env.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 import contextlib
 import io
+import importlib.util
 
 import pytest
 
@@ -31,6 +32,14 @@ DOUBLE_QUOTED="a quoted value"
 SINGLE_QUOTED='a quoted value'
 """
     )
+
+
+def load_module(module_path):
+    spec = importlib.util.spec_from_file_location(module_path.stem, module_path)
+    module = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    spec.loader.exec_module(module)
+    return module
 
 
 def test_load_env(monkeypatch, envmap):
@@ -76,3 +85,45 @@ def test_quoted_value(monkeypatch, envmap):
     env = envex.load_env(search_path=__file__, environ=envmap)
     assert env["DOUBLE_QUOTED"] == "a quoted value"
     assert env["SINGLE_QUOTED"] == "a quoted value"
+
+
+def test_load_env_default_search_path_uses_external_caller(tmp_path, monkeypatch):
+    caller_dir = tmp_path / "caller"
+    caller_dir.mkdir()
+    (caller_dir / ".env").write_text("FROM_CALLER=direct\n")
+    module_path = caller_dir / "caller_module.py"
+    module_path.write_text(
+        "import envex\n"
+        "\n"
+        "def load():\n"
+        "    return envex.load_env(environ={}, update=False, working_dirs=False)\n"
+    )
+    cwd = tmp_path / "cwd"
+    cwd.mkdir()
+    monkeypatch.chdir(cwd)
+
+    module = load_module(module_path)
+    env = module.load()
+
+    assert env["FROM_CALLER"] == "direct"
+
+
+def test_env_readenv_default_search_path_skips_envex_wrappers(tmp_path, monkeypatch):
+    caller_dir = tmp_path / "caller"
+    caller_dir.mkdir()
+    (caller_dir / ".env").write_text("FROM_CALLER=wrapper\n")
+    module_path = caller_dir / "caller_module.py"
+    module_path.write_text(
+        "import envex\n"
+        "\n"
+        "def load():\n"
+        "    return envex.Env(readenv=True, environ={}, update=False, working_dirs=False)\n"
+    )
+    cwd = tmp_path / "cwd"
+    cwd.mkdir()
+    monkeypatch.chdir(cwd)
+
+    module = load_module(module_path)
+    env = module.load()
+
+    assert env["FROM_CALLER"] == "wrapper"

--- a/tests/test_wrapper.py
+++ b/tests/test_wrapper.py
@@ -118,6 +118,45 @@ def test_env_int(monkeypatch):
     assert env.int("DEFAULTINTVALUE", default=981) == 981
     assert env("DEFAULTINTVALUE", default=981, type=int) == 981
     assert env("DEFAULTINTVALUE", type=int) == 981
+    assert env.int("MISSINGINTVALUE") == 0
+
+
+@pytest.mark.parametrize(
+    ("value", "expected"),
+    [
+        ("-42", -42),
+        ("+42", 42),
+        (" 42 ", 42),
+    ],
+)
+def test_env_int_accepts_signed_integer_values(value, expected):
+    env = envex.Env({"PORT": value}, environ={})
+
+    assert env.int("PORT") == expected
+
+
+@pytest.mark.parametrize("value", ["12abc", "4.2", "--42", object()])
+def test_env_int_rejects_invalid_values(value):
+    env = envex.Env(environ={"PORT": value})
+
+    with pytest.raises(ValueError):
+        env.int("PORT")
+
+
+def test_env_kwargs_are_environment_values():
+    env = envex.Env(environ={}, EXTRA_VALUE="extra", PORT=8080, OMITTED=None)
+
+    assert env["EXTRA_VALUE"] == "extra"
+    assert env["PORT"] == "8080"
+    assert "OMITTED" not in env.env
+
+
+def test_env_kwargs_are_not_forwarded_to_load_env(monkeypatch):
+    monkeypatch.setattr(envex.dot_env, "open_env", dotenv)
+
+    env = envex.Env(readenv=True, update=False, environ={}, EXTRA_VALUE="extra")
+
+    assert env["EXTRA_VALUE"] == "extra"
 
 
 def test_env_float(monkeypatch):

--- a/tests/test_wrapper.py
+++ b/tests/test_wrapper.py
@@ -189,6 +189,16 @@ def test_env_kwargs_override_stream_values():
     assert env["FOO"] == "kwarg"
 
 
+def test_streams_load_into_env_returned_by_readenv_update_false(monkeypatch):
+    monkeypatch.setattr(envex.dot_env, "open_env", dotenv)
+    stream = io.BytesIO(b"STREAM_ONLY=stream\n")
+
+    env = envex.Env(stream, readenv=True, update=False, environ={})
+
+    assert env["INTVALUE"] == "225"
+    assert env["STREAM_ONLY"] == "stream"
+
+
 def test_env_streams_kwarg_accepts_iterables():
     def stream_values():
         yield io.BytesIO(b"FIRST=one\n")

--- a/tests/test_wrapper.py
+++ b/tests/test_wrapper.py
@@ -152,11 +152,19 @@ def test_env_kwargs_are_environment_values():
 
 
 def test_env_kwargs_are_not_forwarded_to_load_env(monkeypatch):
-    monkeypatch.setattr(envex.dot_env, "open_env", dotenv)
+    captured_kwargs = {}
+
+    def fake_load_env(**kwargs):
+        captured_kwargs.update(kwargs)
+        return kwargs["environ"]
+
+    monkeypatch.setattr(envex.env_wrapper, "load_env", fake_load_env)
 
     env = envex.Env(readenv=True, update=False, environ={}, EXTRA_VALUE="extra")
 
     assert env["EXTRA_VALUE"] == "extra"
+    assert captured_kwargs["update"] is False
+    assert "EXTRA_VALUE" not in captured_kwargs
 
 
 def test_env_kwargs_override_loaded_env_values(monkeypatch):
@@ -179,6 +187,23 @@ def test_env_kwargs_override_stream_values():
     env = envex.Env(stream, environ={}, FOO="kwarg")
 
     assert env["FOO"] == "kwarg"
+
+
+def test_env_streams_kwarg_accepts_iterables():
+    def stream_values():
+        yield io.BytesIO(b"FIRST=one\n")
+        yield io.StringIO("SECOND=two\n")
+
+    env = envex.Env(streams=stream_values(), environ={})
+
+    assert env["FIRST"] == "one"
+    assert env["SECOND"] == "two"
+
+
+@pytest.mark.parametrize("streams", [object(), ["not a stream"]])
+def test_env_streams_kwarg_rejects_invalid_values(streams):
+    with pytest.raises(TypeError, match="streams must"):
+        envex.Env(streams=streams, environ={})
 
 
 def test_env_float(monkeypatch):

--- a/tests/test_wrapper.py
+++ b/tests/test_wrapper.py
@@ -159,6 +159,28 @@ def test_env_kwargs_are_not_forwarded_to_load_env(monkeypatch):
     assert env["EXTRA_VALUE"] == "extra"
 
 
+def test_env_kwargs_override_loaded_env_values(monkeypatch):
+    monkeypatch.setattr(envex.dot_env, "open_env", dotenv)
+
+    env = envex.Env(
+        readenv=True,
+        update=False,
+        overwrite=True,
+        environ={},
+        INTVALUE=999,
+    )
+
+    assert env["INTVALUE"] == "999"
+
+
+def test_env_kwargs_override_stream_values():
+    stream = io.BytesIO(b"FOO=stream\n")
+
+    env = envex.Env(stream, environ={}, FOO="kwarg")
+
+    assert env["FOO"] == "kwarg"
+
+
 def test_env_float(monkeypatch):
     monkeypatch.setattr(envex.dot_env, "open_env", dotenv)
     env = envex.Env(readenv=True)


### PR DESCRIPTION
Summary
- Make `Env.int()` parse signed integer strings and reject malformed non-empty values.
- Separate recognized Env loader/Vault options from keyword environment overrides.
- Replace default `.env` discovery with a lighter caller-frame lookup that skips envex internals.
- Add agent handoff instructions for repo workflows.

Linear: [UT-189](https://linear.app/uniquode/issue/UT-189/fix-env-parsing-and-default-env-file-discovery)