### PR TITLE
Make invalid encrypted stream tests deterministic

### DIFF
--- a/tests/test_env_crypto.py
+++ b/tests/test_env_crypto.py
@@ -114,7 +114,7 @@ def test_truncated_authenticated_stream_raises_decrypt_error(password):
 
     with pytest.raises(DecryptError) as e:
         decrypt_data(encrypted_stream, password)
-    assert str(e.value) == "Incorrect password or invalid data"
+    assert "invalid data" in str(e.value)
 
 
 def test_invalid_password(incorrect_password, password):

--- a/tests/test_env_crypto.py
+++ b/tests/test_env_crypto.py
@@ -109,6 +109,14 @@ def test_invalid_magic_bytes(encrypted_stream_with_invalid_magic_bytes, password
     assert "does not look to be encrypted" in str(e.value)
 
 
+def test_truncated_authenticated_stream_raises_decrypt_error(password):
+    encrypted_stream = BytesIO(env_crypto.AUTH_MAGIC_BYTES + b"too-short")
+
+    with pytest.raises(DecryptError) as e:
+        decrypt_data(encrypted_stream, password)
+    assert str(e.value) == "Incorrect password or invalid data"
+
+
 def test_invalid_password(incorrect_password, password):
     data = b"VALID_ENCRYPTED_DATA"
     encrypted_data = encrypt_data(BytesIO(data), password)

--- a/tests/test_wrapper.py
+++ b/tests/test_wrapper.py
@@ -688,6 +688,7 @@ def test_encrypted_stream_bytes2(password):
 
 
 def test_encrypted_stream_invalid_plaintext_fallback_decode_error(password):
+    # 0xff/0xfe/0xfa are invalid leading bytes in UTF-8.
     invalid_data = b"\xff\xfe\xfa=not-utf-8\n"
 
     with pytest.raises(UnicodeDecodeError):

--- a/tests/test_wrapper.py
+++ b/tests/test_wrapper.py
@@ -687,11 +687,8 @@ def test_encrypted_stream_bytes2(password):
     assert env("ENABLED") == "true"
 
 
-def test_encrypted_stream_invalid_format(password):
-    import os
-
-    # Create an invalid encrypted format by using random bytes
-    invalid_data = os.urandom(100)
+def test_encrypted_stream_invalid_plaintext_fallback_decode_error(password):
+    invalid_data = b"\xff\xfe\xfa=not-utf-8\n"
 
     with pytest.raises(UnicodeDecodeError):
         envex.Env(io.BytesIO(invalid_data), decrypt=True, password=password)


### PR DESCRIPTION
Summary
- Replace random invalid encrypted stream input with deterministic invalid UTF-8 bytes.
- Add focused coverage for truncated authenticated encrypted streams raising `DecryptError`.

Linear: [UT-190](https://linear.app/uniquode/issue/UT-190/make-invalid-encrypted-stream-tests-deterministic)