### PR TITLE
UT-191: Fix dotenv parsing edge cases

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -3,5 +3,5 @@
 - Read `.todo/context.md` before starting repo work; it contains the current project-specific workflow, PR, Linear, and git conventions.
 - Update `.todo/context.md` at the conclusion of each work iteration so the next handoff has current status and decisions.
 - Use `.todo/` for working notes, temporary plans, review handoffs, and other short-lived coordination documents.
-- Do not include temporary `.todo/` working documents in normal commits unless explicitly asked.
+- `.todo/` content is ignored and is not part of the persistent repository.
 - Where an issue prefix is available, use it as a prefix on the pull request title.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,3 +4,4 @@
 - Update `.todo/context.md` at the conclusion of each work iteration so the next handoff has current status and decisions.
 - Use `.todo/` for working notes, temporary plans, review handoffs, and other short-lived coordination documents.
 - Do not include temporary `.todo/` working documents in normal commits unless explicitly asked.
+- Where an issue prefix is available, use it as a prefix on the pull request title.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,9 @@
 - `Env.int()` now parses signed integer strings correctly and raises `ValueError` for malformed non-empty integer values instead of silently returning `0`.
 - `Env(...)` now separates recognized loader/Vault options from additional environment-variable kwargs, so keyword environment overrides behave as documented.
 - Default `.env` discovery now uses a lightweight caller-frame lookup that skips envex-internal wrapper frames instead of relying on `inspect.stack()[1]`.
+- Dotenv parsing now preserves intentional empty values such as `KEY=` and `export KEY=`.
+- Missing dotenv files are now handled explicitly without yielding phantom paths or setting `PWD` for nonexistent files.
+- Encrypted-looking streams now raise `DecryptError` when decryption fails instead of falling back to plaintext parsing; plaintext fallback remains available for non-encrypted-looking streams.
 - Test Vault container setup now avoids deprecated `testcontainers.vault.VaultContainer` imports, keeping warning-as-error test collection clean.
 - Documentation now uses the official HashiCorp Vault capitalization.
 

--- a/envex/dot_env.py
+++ b/envex/dot_env.py
@@ -1,4 +1,5 @@
 # -*- coding: utf-8 -*-
+import errno
 import os
 import sys
 import contextlib
@@ -76,8 +77,16 @@ def _env_files(
             try:
                 with open_env(path):
                     return True
-            except OSError:
-                return False
+            except OSError as exc:
+                if exc.errno in {
+                    errno.EACCES,
+                    errno.ENOENT,
+                    errno.ENOTDIR,
+                    errno.EPERM,
+                    errno.EISDIR,
+                }:
+                    return False
+                raise
 
         if _decrypt:
             encrypted_path = os.path.join(base_path, name + ENCRYPTED_EXT)
@@ -88,14 +97,21 @@ def _env_files(
         return standard_path if readable(standard_path) else None
 
     searched = []
+    seen = set()
     found = False
+
+    def record_search(path: Path) -> None:
+        if path not in seen:
+            searched.append(path)
+            seen.add(path)
+
     for path in search_path:
         path = path.resolve()
         if not path.is_dir():
             path = path.parent
-        searched.append(path)
 
         for sub_path in [path] + list(path.parents):
+            record_search(sub_path)
             env_path = resolve_file(sub_path, env_file, decrypt)
             if env_path is not None:
                 found = True

--- a/envex/dot_env.py
+++ b/envex/dot_env.py
@@ -15,7 +15,7 @@ from typing import (
     Generator,
 )
 
-from .env_crypto import decrypt_data, DecryptError
+from .env_crypto import AUTH_MAGIC_BYTES, MAGIC_BYTES, decrypt_data, DecryptError
 
 __all__ = (
     "load_env",
@@ -35,6 +35,7 @@ DEFAULT_ENCODING = "utf-8"
 _MODIFIER_PATTERN = re.compile(r":([-+])")
 _VAR_BRACES_PATTERN = re.compile(r"\${([^{}]+)}")
 _VAR_NO_BRACES_PATTERN = re.compile(r"\$([a-zA-Z_][a-zA-Z0-9_]*)")
+_DOTENV_ASSIGNMENT_PREFIX_PATTERN = re.compile(r"[a-zA-Z_][a-zA-Z0-9_]*\s*=")
 _PACKAGE_ROOT = Path(__file__).resolve().parent
 
 
@@ -52,14 +53,14 @@ def update_env(env: MutableMapping[str, str], mapping: Dict):
 def _env_default(
     environ: MutableMapping[str, str], key: str, val: str, overwrite: bool = False
 ):
-    if key and val and (overwrite or key not in environ):
+    if key and val is not None and (overwrite or key not in environ):
         environ[key] = val
 
 
 def _env_export(
     environ: MutableMapping[str, str], key: str, val: str, overwrite: bool = False
 ):
-    if key and val and (overwrite or key not in environ):
+    if key and val is not None and (overwrite or key not in environ):
         environ[key] = val
 
 
@@ -70,15 +71,24 @@ def _env_files(
 
     def resolve_file(base_path: Path, name: str, _decrypt: bool) -> Optional[str]:
         """Returns the path to the env file, prioritising the encrypted version if enabled"""
+
+        def readable(path: str) -> bool:
+            try:
+                with open_env(path):
+                    return True
+            except OSError:
+                return False
+
         if _decrypt:
             encrypted_path = os.path.join(base_path, name + ENCRYPTED_EXT)
-            if os.access(encrypted_path, os.R_OK):
+            if readable(encrypted_path):
                 return encrypted_path
 
         standard_path = os.path.join(base_path, name)
-        return standard_path if os.access(standard_path, os.R_OK) else None
+        return standard_path if readable(standard_path) else None
 
     searched = []
+    found = False
     for path in search_path:
         path = path.resolve()
         if not path.is_dir():
@@ -88,15 +98,14 @@ def _env_files(
         for sub_path in [path] + list(path.parents):
             env_path = resolve_file(sub_path, env_file, decrypt)
             if env_path is not None:
+                found = True
                 yield env_path
                 break
             elif not parents:
                 break
 
-    if errors:
+    if errors and not found:
         raise FileNotFoundError(f"{env_file} in {[s.as_posix() for s in searched]}")
-    else:
-        yield env_file
 
 
 @contextlib.contextmanager
@@ -176,12 +185,12 @@ def _process_env(
     files_not_found = []
     files_found = False
     for env_path in _env_files(env_file, search_path, parents, decrypt, errors):
-        # insert PWD as the container of the env file
         env_path = Path(env_path).resolve()
-        if working_dirs:
-            environ["PWD"] = str(env_path.parent)
         try:
             with open_env(env_path) as f:
+                # insert PWD as the container of the env file
+                if working_dirs:
+                    environ["PWD"] = str(env_path.parent)
                 data = f.read()
                 if isinstance(data, str):
                     data = data.encode(encoding)
@@ -273,7 +282,7 @@ def _post_process(environ: MutableMapping[str, str]) -> MutableMapping[str, str]
     - ${VAR:+value} - Use value only if VAR is set
     - $VAR - Variable substitution without braces
     """
-    for key, val in environ.items():
+    for key, val in list(environ.items()):
         if "$" in val:  # Potential variable reference!
             new_val = _process_nested_vars(val, environ)
             if new_val != val:
@@ -404,11 +413,34 @@ def load_stream(
         stream = BytesIO(stream.read().encode(encoding))
     elif password and decrypt:
         stream_pos = stream.tell()
+        header = stream.read(len(MAGIC_BYTES))
+        stream.seek(stream_pos)
+        encrypted_header = header in (MAGIC_BYTES, AUTH_MAGIC_BYTES)
         try:
             stream = decrypt_data(stream, password)
         except DecryptError:
             stream.seek(stream_pos)
+            if encrypted_header and (
+                _is_encrypted_env_path(env_path)
+                or not _looks_like_plaintext_dotenv(stream, encoding)
+            ):
+                raise
     _process_stream(stream, environ, overwrite, errors, encoding, env_path)
+
+
+def _is_encrypted_env_path(env_path: Optional[Path]) -> bool:
+    return env_path is not None and env_path.name.endswith(ENCRYPTED_EXT)
+
+
+def _looks_like_plaintext_dotenv(stream: BytesIO, encoding: str) -> bool:
+    stream_pos = stream.tell()
+    try:
+        line = stream.readline().decode(encoding).strip()
+    except UnicodeDecodeError:
+        return False
+    finally:
+        stream.seek(stream_pos)
+    return bool(_DOTENV_ASSIGNMENT_PREFIX_PATTERN.match(line))
 
 
 load_dotenv = load_env

--- a/tests/test_load_env.py
+++ b/tests/test_load_env.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 import contextlib
+import errno
 import io
 import importlib.util
 
@@ -156,6 +157,35 @@ def test_missing_env_file_errors_true_raises(tmp_path):
             update=False,
             errors=True,
         )
+
+
+def test_missing_env_file_error_lists_parent_search_paths(tmp_path):
+    nested = tmp_path / "project" / "child"
+    nested.mkdir(parents=True)
+
+    with pytest.raises(FileNotFoundError) as exc_info:
+        envex.load_env(
+            env_file=".missing",
+            search_path=nested,
+            environ={},
+            update=False,
+            errors=True,
+            parents=True,
+        )
+
+    message = str(exc_info.value)
+    assert nested.resolve().as_posix() in message
+    assert nested.parent.resolve().as_posix() in message
+
+
+def test_env_file_probe_reraises_unexpected_oserror(tmp_path, monkeypatch):
+    def broken_open_env(_path):
+        raise OSError(errno.EIO, "read failure")
+
+    monkeypatch.setattr(envex.dot_env, "open_env", broken_open_env)
+
+    with pytest.raises(OSError, match="read failure"):
+        envex.load_env(search_path=tmp_path, environ={}, update=False)
 
 
 def test_post_process_iterates_over_snapshot():

--- a/tests/test_load_env.py
+++ b/tests/test_load_env.py
@@ -71,6 +71,116 @@ def test_export_command_updates_os_environ_only_when_requested(monkeypatch, envm
     assert envex.dot_env.os.environ["FIFTH"] == "fifth-value"
 
 
+def test_empty_values_are_preserved(tmp_path):
+    env_file = tmp_path / ".env"
+    env_file.write_text("EMPTY=\n")
+
+    env = envex.load_env(search_path=tmp_path, environ={}, update=False)
+
+    assert env["EMPTY"] == ""
+
+
+def test_empty_values_follow_overwrite_semantics(tmp_path):
+    env_file = tmp_path / ".env"
+    env_file.write_text("EMPTY=\n")
+
+    preserved = envex.load_env(
+        search_path=tmp_path,
+        environ={"EMPTY": "existing"},
+        update=False,
+        overwrite=False,
+    )
+    overwritten = envex.load_env(
+        search_path=tmp_path,
+        environ={"EMPTY": "existing"},
+        update=False,
+        overwrite=True,
+    )
+
+    assert preserved["EMPTY"] == "existing"
+    assert overwritten["EMPTY"] == ""
+
+
+def test_export_empty_value_respects_isolated_environ(tmp_path, monkeypatch):
+    monkeypatch.delenv("EMPTY", raising=False)
+    env_file = tmp_path / ".env"
+    env_file.write_text("export EMPTY=\n")
+
+    env = envex.load_env(search_path=tmp_path, environ={}, update=False)
+
+    assert env["EMPTY"] == ""
+    assert "EMPTY" not in envex.dot_env.os.environ
+
+
+def test_export_empty_values_follow_overwrite_semantics(tmp_path):
+    env_file = tmp_path / ".env"
+    env_file.write_text("export EMPTY=\n")
+
+    preserved = envex.load_env(
+        search_path=tmp_path,
+        environ={"EMPTY": "existing"},
+        update=False,
+        overwrite=False,
+    )
+    overwritten = envex.load_env(
+        search_path=tmp_path,
+        environ={"EMPTY": "existing"},
+        update=False,
+        overwrite=True,
+    )
+
+    assert preserved["EMPTY"] == "existing"
+    assert overwritten["EMPTY"] == ""
+
+
+def test_missing_env_file_does_not_yield_phantom_path(tmp_path):
+    env = envex.load_env(
+        env_file=".missing",
+        search_path=tmp_path,
+        environ={"EXISTING": "value"},
+        update=False,
+        working_dirs=True,
+    )
+
+    assert env["EXISTING"] == "value"
+    assert "CWD" in env
+    assert "PWD" not in env
+
+
+def test_missing_env_file_errors_true_raises(tmp_path):
+    with pytest.raises(FileNotFoundError):
+        envex.load_env(
+            env_file=".missing",
+            search_path=tmp_path,
+            environ={},
+            update=False,
+            errors=True,
+        )
+
+
+def test_post_process_iterates_over_snapshot():
+    class IterationGuard(dict):
+        iterating = False
+
+        def items(self):
+            self.iterating = True
+            try:
+                yield from super().items()
+            finally:
+                self.iterating = False
+
+        def __setitem__(self, key, value):
+            if self.iterating:
+                raise RuntimeError("mutation during iteration")
+            super().__setitem__(key, value)
+
+    env = IterationGuard({"BASE": "value", "COMBINED": "$BASE"})
+
+    result = envex.dot_env._post_process(env)
+
+    assert result["COMBINED"] == "value"
+
+
 def test_load_env_overwrite(monkeypatch, envmap):
     monkeypatch.setattr(envex.dot_env, "open_env", dotenv)
     env = envex.load_env(search_path=__file__, environ=envmap, overwrite=True)

--- a/tests/test_wrapper.py
+++ b/tests/test_wrapper.py
@@ -5,7 +5,8 @@ import io
 import pytest
 
 import envex
-from envex.env_crypto import encrypt_data
+import envex.env_crypto as env_crypto
+from envex.env_crypto import DecryptError, encrypt_data
 
 TEST_ENV = [
     "# This is an example .env file",
@@ -648,6 +649,47 @@ def test_plain_stream_with_env_password_is_not_corrupted(password):
     assert env("ONE") == "1"
     assert env("ARG2") == "two"
     assert env("ENABLED") == "true"
+
+
+@pytest.mark.parametrize("key", ["SECG_KEY", "SECF_KEY"])
+def test_plain_stream_magic_prefix_key_with_env_password_is_not_rejected(password, key):
+    stream = io.BytesIO(f"{key}=value\n".encode())
+
+    env = envex.Env(stream, environ={"ENV_PASSWORD": password})
+
+    assert env[key] == "value"
+
+
+@pytest.mark.parametrize("key", ["SECG_KEY", "SECF_KEY"])
+def test_plain_env_file_magic_prefix_key_with_env_password_is_not_rejected(
+    password, tmp_path, key
+):
+    env_file = tmp_path / ".env"
+    env_file.write_text(f"{key}=value\n")
+
+    env = envex.Env(
+        readenv=True,
+        environ={"ENV_PASSWORD": password},
+        env_file=".env",
+        search_path=tmp_path,
+        update=False,
+    )
+
+    assert env[key] == "value"
+
+
+def test_encrypted_stream_wrong_password_raises_decrypt_error(password):
+    stream = encrypt_data(io.BytesIO(b"ONE=1\n"), password)
+
+    with pytest.raises(DecryptError):
+        envex.Env(stream, decrypt=True, password="wrong-password")
+
+
+def test_legacy_encrypted_stream_without_opt_in_raises_decrypt_error(password):
+    stream = io.BytesIO(env_crypto.MAGIC_BYTES + b"legacy-data")
+
+    with pytest.raises(DecryptError, match="Legacy AES-CBC data requires explicit"):
+        envex.Env(stream, decrypt=True, password=password)
 
 
 def test_decrypt_false_ignores_env_password(password, tmp_path):


### PR DESCRIPTION
Summary
- Preserve intentional empty dotenv values and keep overwrite behavior covered.
- Avoid mutating dotenv mappings during post-processing iteration.
- Handle missing dotenv files explicitly without phantom paths.
- Raise on encrypted-looking stream decrypt failures while preserving plaintext fallback.

Linear: [UT-191](https://linear.app/uniquode/issue/UT-191/fix-dotenv-parsing-edge-cases)