### PR TITLE
UT-192: Clean up Env source and export API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,29 +2,17 @@
 
 ### v5.0.0
 
-- ⚠️ BREAKING CHANGE ⚠️: encrypted files created by envex now use authenticated AES-256-GCM instead of the legacy AES-CBC format.
-- Files encrypted with envex 5.0.0 or later cannot be decrypted by envex 4.x or older. Envex 5.0.0 can still decrypt legacy AES-CBC files so they can be migrated.
-- Legacy AES-CBC decryption now requires explicit legacy mode during migration; normal decryption rejects legacy headers to prevent downgrade from authenticated AES-GCM into the unauthenticated legacy path.
-- The encryption format changed because the previous AES-CBC format did not authenticate ciphertext and could be vulnerable to padding-oracle style attacks if decryption errors were exposed.
-- To migrate existing files, decrypt the legacy `.env.enc` file with a version that can read it, then re-encrypt it with envex 5.0.0 or later using
-  - `envcrypt --decrypt --legacy ...`, followed by
-  - `envcrypt --encrypt ...`.
-- ⚠️ BREAKING CHANGE ⚠️: `SecretsManager.base_path` and `SecretsManager.path()` now represent logical KV v2 secret paths instead of raw Vault API paths such as `secret/data/...`. Direct `SecretsManager` users that passed or compared raw API paths should migrate to logical paths and use `mount_point` for the Vault secrets engine mount, which defaults to `secret/`.
-- Vault secret reads, writes, and deletes now use hvac's KV v2 API instead of raw `client.read()`, `client.write()`, and `client.delete()` calls. This improves behavior with namespaces and non-standard mount points.
-- `SecretsManager` Vault initialization failures are now instance-local; one transient failure no longer disables Vault lookups for all later instances in the process.
-- The optional Vault integration remains importable when `hvac` is not installed.
-- Vault client certificate environment handling now validates PEM files and passes file paths to hvac/requests. `VAULT_CLIENT_CERT` may point to a combined certificate/key PEM file, or `VAULT_CLIENT_CERT` and `VAULT_CLIENT_KEY` may point to separate files. Incomplete client certificate configuration now logs a warning.
-- `SecretsManager.set_secrets(path, values={})` is non-destructive; use `delete_secrets(path)` to delete a secret document explicitly.
-- `.env` `export` lines no longer bypass isolated environment mappings by writing directly to `os.environ`; global process updates remain controlled by `load_env(update=True)` or explicit `Env.export()`.
-- `Env.set(..., None)` now treats `None` as unset, and `Env.setdefault(..., None)` no longer stores `None`. Dict arguments passed to `Env(...)` use the same setter semantics, so `None` is not stringified as `"None"`.
-- `Env.int()` now parses signed integer strings correctly and raises `ValueError` for malformed non-empty integer values instead of silently returning `0`.
-- `Env(...)` now separates recognized loader/Vault options from additional environment-variable kwargs, so keyword environment overrides behave as documented.
-- Default `.env` discovery now uses a lightweight caller-frame lookup that skips envex-internal wrapper frames instead of relying on `inspect.stack()[1]`.
-- Dotenv parsing now preserves intentional empty values such as `KEY=` and `export KEY=`.
-- Missing dotenv files are now handled explicitly without yielding phantom paths or setting `PWD` for nonexistent files.
-- Encrypted-looking streams now raise `DecryptError` when decryption fails instead of falling back to plaintext parsing; plaintext fallback remains available for non-encrypted-looking streams.
-- Test Vault container setup now avoids deprecated `testcontainers.vault.VaultContainer` imports, keeping warning-as-error test collection clean.
-- Documentation now uses the official HashiCorp Vault capitalization.
+- ⚠️ BREAKING CHANGE ⚠️: encrypted files now use authenticated AES-256-GCM. Files encrypted by envex 5.0.0 or later cannot be decrypted by envex 4.x or older.
+- Legacy AES-CBC files can be migrated with `envcrypt --decrypt --legacy ...` followed by `envcrypt --encrypt ...`.
+- ⚠️ BREAKING CHANGE ⚠️: `SecretsManager.base_path` and `SecretsManager.path()` now use logical KV v2 paths. Direct `SecretsManager` users should use `mount_point` for the Vault secrets engine mount.
+- Vault secret reads, writes, and deletes now use hvac's KV v2 API.
+- Vault client certificate configuration now supports either a combined PEM file or separate certificate/key files.
+- `SecretsManager.set_secrets(path, values={})` is non-destructive; use `delete_secrets(path)` to delete a secret document.
+- `.env` `export` lines now respect isolated environment mappings.
+- `Env.set(..., None)` and `Env.setdefault(..., None)` now treat `None` as unset.
+- `Env.int()` now parses signed integer strings and raises `ValueError` for malformed non-empty values.
+- Extra `Env(...)` keyword environment values now apply after loader and Vault options.
+- Dotenv parsing now preserves empty values, handles missing files explicitly, and raises `DecryptError` for encrypted-looking streams that fail to decrypt.
 
 ### v4.4.0
 
@@ -126,8 +114,8 @@ These changes allow full configuration of the secrets manager backend using the 
   - install optional "hvac" dependency to enable, else no-op
   - read hvac documentation for usage (eg VAULT_TOKEN and VAULT_ADDR)
   - by default, environment values override vault ones. To modify this
-    behaviour, set ENVEX_SRC=vault to have vault values override.
-    ENVEX_SRC=env by default.
+    behaviour, set ENVEX_SOURCE=vault to have vault values override.
+    ENVEX_SOURCE=env by default.
   - args to Env() added to support vault client configuration
   - vault secrets are cached by default
   - base_path arg may be used to set a based vault path, i.e. f"/secret/{base_path}/key",

--- a/README.md
+++ b/README.md
@@ -117,6 +117,8 @@ In addition, Env supports a few HashiCorp Vault configuration parameters as well
 * enable_cache: bool whether to cache values fetched from Vault (default is True)
   This is used to prefix the logical path to the secret, i.e. `f"{base_path}/key"`.
 
+Environment values override Vault values by default. Set `ENVEX_SOURCE=vault` to let Vault values override local environment values.
+
 Some type-smart functions act as an alternative to `Env.get` and having to parse the result:
 ```python
 from envex import env

--- a/envex/env_wrapper.py
+++ b/envex/env_wrapper.py
@@ -5,6 +5,7 @@ Type smart wrapper around os.environ
 
 import contextlib
 import inspect
+import os
 import re
 from pathlib import Path
 from io import TextIOBase, BytesIO
@@ -26,6 +27,7 @@ class Env:
     _BOOLEAN_FALSE_STRINGS = frozenset(("", "0", "f", "false", "n", "no", "off"))
     _EXCEPTION_CLS = KeyError
     _LOAD_ENV_KWARGS = frozenset(inspect.signature(load_env).parameters)
+    _SOURCE_KEY = "ENVEX_SOURCE"
 
     def __init__(
         self,
@@ -68,6 +70,8 @@ class Env:
         @param base_path: (optional) str base path for secrets (default=None)
         @param engine: (optional) str vault secrets engine (default=None)
         @param mount_point: (optional) str vault secrets mount point (default=None, determined by engine)
+        Environment values override Vault by default. Set ENVEX_SOURCE=vault
+            to let Vault values override local values.
         @param working_dirs: (optional) bool whether to include PWD/CWD (default=True)
             -
         @param timeout: (optional) int timeout for requests sent to Vault.
@@ -104,7 +108,7 @@ class Env:
             load_env_kwargs["environ"] = self._env
         self.read_streams(*streams, **load_env_kwargs)
         self.set(kwargs)
-        self.env_source = self.env.get("ENVEX_SOURCE", "env") == "env"
+        self.env_source = self._resolve_env_source() == "env"
         vault_verify = (
             verify
             if verify is not None
@@ -167,9 +171,10 @@ class Env:
 
     @staticmethod
     def os_env():
-        import os
-
         return os.environ
+
+    def _resolve_env_source(self) -> str:
+        return self.env.get(self._SOURCE_KEY, "env")
 
     def read_env(self, **kwargs):
         """
@@ -294,8 +299,6 @@ class Env:
         return self.get(var, default)
 
     def export(self, *args, **kwargs):
-        import os
-
         for arg in args:
             if not isinstance(arg, (dict,)):
                 raise TypeError(
@@ -306,15 +309,12 @@ class Env:
             kwargs = self.env
         for k, v in kwargs.items():
             k = str(k)
-            try:
-                if v is None:
-                    self.unset(k)
-                    del os.environ[k]
-                else:
-                    self.set(k, v)
-                    os.environ[k] = str(v)
-            except KeyError:
-                ...
+            if v is None:
+                self.unset(k)
+                os.environ.pop(k, None)
+            else:
+                self.set(k, v)
+                os.environ[k] = str(v)
 
     @classmethod
     def is_true(cls, val):

--- a/envex/env_wrapper.py
+++ b/envex/env_wrapper.py
@@ -28,6 +28,7 @@ class Env:
     _EXCEPTION_CLS = KeyError
     _LOAD_ENV_KWARGS = frozenset(inspect.signature(load_env).parameters)
     _SOURCE_KEY = "ENVEX_SOURCE"
+    _SOURCE_VALUES = frozenset(("env", "vault"))
 
     def __init__(
         self,
@@ -174,7 +175,10 @@ class Env:
         return os.environ
 
     def _resolve_env_source(self) -> str:
-        return self.env.get(self._SOURCE_KEY, "env")
+        source = str(self.env.get(self._SOURCE_KEY, "env")).strip().lower()
+        if source not in self._SOURCE_VALUES:
+            raise ValueError(f"Invalid {self._SOURCE_KEY} value: {source!r}")
+        return source
 
     def read_env(self, **kwargs):
         """

--- a/tests/test_wrapper.py
+++ b/tests/test_wrapper.py
@@ -375,6 +375,49 @@ def test_env_source_uses_canonical_variable_for_vault_precedence(monkeypatch):
     assert env.get("SECRET") == "vault"
 
 
+@pytest.mark.parametrize("source", ["vault", " Vault ", "VAULT"])
+def test_env_source_normalizes_vault_precedence(source, monkeypatch):
+    class FakeSecretsManager:
+        def __init__(self, **_kwargs):
+            pass
+
+        def get_secret(self, key, default=None):
+            return {"SECRET": "vault"}.get(key, default)
+
+    monkeypatch.setattr("envex.env_wrapper.SecretsManager", FakeSecretsManager)
+
+    env = envex.Env(environ={"ENVEX_SOURCE": source, "SECRET": "env"})
+
+    assert env.get("SECRET") == "vault"
+
+
+@pytest.mark.parametrize("source", ["env", " ENV ", "ENV"])
+def test_env_source_normalizes_env_precedence(source, monkeypatch):
+    class FakeSecretsManager:
+        def __init__(self, **_kwargs):
+            pass
+
+        def get_secret(self, key, default=None):
+            return {"SECRET": "vault"}.get(key, default)
+
+    monkeypatch.setattr("envex.env_wrapper.SecretsManager", FakeSecretsManager)
+
+    env = envex.Env(environ={"ENVEX_SOURCE": source, "SECRET": "env"})
+
+    assert env.get("SECRET") == "env"
+
+
+def test_invalid_env_source_raises_value_error_before_vault_init(monkeypatch):
+    class FakeSecretsManager:
+        def __init__(self, **_kwargs):
+            raise AssertionError("SecretsManager should not be initialized")
+
+    monkeypatch.setattr("envex.env_wrapper.SecretsManager", FakeSecretsManager)
+
+    with pytest.raises(ValueError, match="Invalid ENVEX_SOURCE value"):
+        envex.Env(environ={"ENVEX_SOURCE": "treu"})
+
+
 def test_env_list(monkeypatch):
     monkeypatch.setattr(envex.dot_env, "open_env", dotenv)
     env = envex.Env(readenv=True)

--- a/tests/test_wrapper.py
+++ b/tests/test_wrapper.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 import contextlib
 import io
+import os
 
 import pytest
 
@@ -359,6 +360,21 @@ def test_is_set_uses_secret_manager_values():
     assert not env.is_set("MISSING_SECRET")
 
 
+def test_env_source_uses_canonical_variable_for_vault_precedence(monkeypatch):
+    class FakeSecretsManager:
+        def __init__(self, **_kwargs):
+            pass
+
+        def get_secret(self, key, default=None):
+            return {"SECRET": "vault"}.get(key, default)
+
+    monkeypatch.setattr("envex.env_wrapper.SecretsManager", FakeSecretsManager)
+
+    env = envex.Env(environ={"ENVEX_SOURCE": "vault", "SECRET": "env"})
+
+    assert env.get("SECRET") == "vault"
+
+
 def test_env_list(monkeypatch):
     monkeypatch.setattr(envex.dot_env, "open_env", dotenv)
     env = envex.Env(readenv=True)
@@ -459,6 +475,17 @@ def test_env_export():
     env.export()
     for k, v in values.items():
         assert os.environ[k] == str(v)
+
+
+def test_env_export_none_removes_process_env_without_keyerror(monkeypatch):
+    monkeypatch.setenv("REMOVE_ME", "value")
+    env = envex.Env({"REMOVE_ME": "value"}, environ={})
+
+    env.export(REMOVE_ME=None)
+    env.export(REMOVE_ME=None)
+
+    assert "REMOVE_ME" not in env.env
+    assert "REMOVE_ME" not in os.environ
 
 
 def test_env_contains(monkeypatch):


### PR DESCRIPTION
Summary
- Use `ENVEX_SOURCE` as the only Vault source selector and remove the old spelling from code/tests/docs.
- Clean up `Env.export()` unset handling with explicit `os.environ.pop(k, None)` behavior.
- Trim the v5.0.0 changelog to user-facing changes.

Linear: [UT-192](https://linear.app/uniquode/issue/UT-192/clean-up-env-source-docs-and-export-api)