### PR TITLE
UT-193: Clean up maintenance debt

### DIFF
--- a/envex/dot_env.py
+++ b/envex/dot_env.py
@@ -4,17 +4,10 @@ import os
 import sys
 import contextlib
 import re
+from collections.abc import Generator, MutableMapping, Sequence
 from io import TextIOBase, BytesIO, BufferedReader
 from pathlib import Path
-from typing import (
-    Dict,
-    List,
-    MutableMapping,
-    Union,
-    Optional,
-    Any,
-    Generator,
-)
+from typing import Any
 
 from .env_crypto import AUTH_MAGIC_BYTES, MAGIC_BYTES, decrypt_data, DecryptError
 
@@ -46,7 +39,7 @@ def unquote(line, quotes="\"'"):
     return line
 
 
-def update_env(env: MutableMapping[str, str], mapping: Dict):
+def update_env(env: MutableMapping[str, str], mapping: dict):
     for k, v in mapping.items():
         env[str(k)] = str(v)
 
@@ -66,11 +59,11 @@ def _env_export(
 
 
 def _env_files(
-    env_file: str, search_path: List[Path], parents: bool, decrypt: bool, errors: bool
+    env_file: str, search_path: list[Path], parents: bool, decrypt: bool, errors: bool
 ) -> Generator[str, Any, None]:
     """expand env_file with the full search path, optionally parents as well"""
 
-    def resolve_file(base_path: Path, name: str, _decrypt: bool) -> Optional[str]:
+    def resolve_file(base_path: Path, name: str, _decrypt: bool) -> str | None:
         """Returns the path to the env file, prioritising the encrypted version if enabled"""
 
         def readable(path: str) -> bool:
@@ -125,7 +118,7 @@ def _env_files(
 
 
 @contextlib.contextmanager
-def open_env(path: Union[str, Path]) -> Generator[BufferedReader, Any, None]:
+def open_env(path: str | Path) -> Generator[BufferedReader, Any, None]:
     """same as open, allow monkeypatch"""
     fp = open(path, "rb")
     try:
@@ -175,14 +168,14 @@ def _process_stream(
 
 def _process_env(
     env_file: str,
-    search_path: List[Path],
+    search_path: list[Path],
     environ: MutableMapping[str, str],
     overwrite: bool,
     parents: bool,
     errors: bool,
     working_dirs: bool,
     decrypt: bool,
-    password: Optional[str] = None,
+    password: str | None = None,
     encoding: str = DEFAULT_ENCODING,
 ) -> MutableMapping[str, str]:
     """
@@ -341,9 +334,14 @@ def _default_search_path() -> list[str]:
         del frame
 
 
+def _decode_filesystem_path(path: bytes) -> str:
+    fs_encoding = sys.getfilesystemencoding() or "utf-8"
+    return path.decode(fs_encoding, errors="surrogateescape")
+
+
 def load_env(
     env_file: str | Path | None = None,
-    search_path: Union[None, Union[List[str], List[Path]], str] = None,
+    search_path: str | bytes | Path | Sequence[str | bytes | Path] | None = None,
     environ: MutableMapping[str, str] | None = None,
     overwrite: bool = False,
     parents: bool = False,
@@ -381,23 +379,30 @@ def load_env(
 
     # determine where to search
     if search_path is None:
-        search_path = _default_search_path()
+        search_paths = _default_search_path()
     elif isinstance(search_path, Path):
-        search_path = [search_path]
-    elif isinstance(search_path, (str, bytes)):
-        search_path = search_path.split(os.pathsep)
+        search_paths = [search_path]
+    elif isinstance(search_path, bytes):
+        search_paths = _decode_filesystem_path(search_path).split(os.pathsep)
+    elif isinstance(search_path, str):
+        search_paths = search_path.split(os.pathsep)
+    else:
+        search_paths = search_path
     # convert to the array of Path for use internally
-    search_path = [Path(p) for p in search_path]
+    resolved_search_path = [
+        Path(_decode_filesystem_path(p) if isinstance(p, bytes) else p)
+        for p in search_paths
+    ]
     # if overwriting, traverse the path in reverse order so the first .env files have priority
     if overwrite:
-        search_path.reverse()
+        resolved_search_path.reverse()
 
     # slurp up the environment files found and
     # post-process values for template variables
     environ = _post_process(
         _process_env(
             env_file,
-            search_path,
+            resolved_search_path,
             dict(environ),
             overwrite,
             parents,
@@ -413,14 +418,14 @@ def load_env(
 
 
 def load_stream(
-    stream: Union[BytesIO, TextIOBase],
+    stream: BytesIO | TextIOBase,
     environ: MutableMapping[str, str] | None = None,
     overwrite: bool = False,
     errors: bool = False,
     decrypt: bool = False,
-    password: Optional[str] = None,
+    password: str | None = None,
     encoding: str = DEFAULT_ENCODING,
-    env_path: Optional[Path] = None,
+    env_path: Path | None = None,
 ):
     if environ is None:
         environ = os.environ
@@ -444,7 +449,7 @@ def load_stream(
     _process_stream(stream, environ, overwrite, errors, encoding, env_path)
 
 
-def _is_encrypted_env_path(env_path: Optional[Path]) -> bool:
+def _is_encrypted_env_path(env_path: Path | None) -> bool:
     return env_path is not None and env_path.name.endswith(ENCRYPTED_EXT)
 
 

--- a/envex/dot_env.py
+++ b/envex/dot_env.py
@@ -4,7 +4,7 @@ import os
 import sys
 import contextlib
 import re
-from collections.abc import Generator, MutableMapping, Sequence
+from collections.abc import Generator, Iterable, MutableMapping
 from io import TextIOBase, BytesIO, BufferedReader
 from pathlib import Path
 from typing import Any
@@ -341,7 +341,7 @@ def _decode_filesystem_path(path: bytes) -> str:
 
 def load_env(
     env_file: str | Path | None = None,
-    search_path: str | bytes | Path | Sequence[str | bytes | Path] | None = None,
+    search_path: str | bytes | Path | Iterable[str | bytes | Path] | None = None,
     environ: MutableMapping[str, str] | None = None,
     overwrite: bool = False,
     parents: bool = False,

--- a/envex/env_crypto.py
+++ b/envex/env_crypto.py
@@ -6,10 +6,6 @@ import logging
 import secrets
 from io import BytesIO, TextIOBase
 
-__all__ = ("encrypt_data", "decrypt_data", "EncryptError", "DecryptError")
-
-from typing import Union
-
 # Magic bytes to identify encrypted files. The legacy prefix is retained so
 # existing AES-CBC files can still be detected and decrypted.
 MAGIC_BYTES = b"SECF"  # "Secure Encrypted File"
@@ -25,6 +21,8 @@ GCM_TAG_LENGTH = 16
 DECRYPT_ERROR_MESSAGE = "Incorrect password or invalid data"
 
 logger = logging.getLogger(__file__)
+
+__all__ = ("encrypt_data", "decrypt_data", "EncryptError", "DecryptError")
 
 
 class DecryptError(ValueError):
@@ -78,7 +76,7 @@ try:
         )
         return key, salt
 
-    def _read_stream(input_stream: Union[BytesIO, TextIOBase], encoding: str) -> BytesIO:
+    def _read_stream(input_stream: BytesIO | TextIOBase, encoding: str) -> BytesIO:
         if not isinstance(input_stream, BytesIO):
             input_stream.seek(0)
             data = input_stream.read()
@@ -96,7 +94,7 @@ try:
         return input_stream.read(len(MAGIC_BYTES))
 
     def encrypt_data(
-        input_stream: Union[BytesIO, TextIOBase], password: str, encoding: str = "utf-8"
+        input_stream: BytesIO | TextIOBase, password: str, encoding: str = "utf-8"
     ) -> BytesIO:
         """
         Encrypt a file using AES-256-GCM with a password-derived key.
@@ -173,14 +171,15 @@ try:
         return _decrypt_legacy_cbc(input_stream, password)
 
 
-except ImportError as e:
-    once = False
-    if not once:
-        once = True
-        logger.warning("Crypto module not found, encryption not available")
-        logger.exception(e)
+except ImportError:
+    logger.warning("Crypto module not found, encryption and decryption are not available")
+    logger.debug("Crypto import failure", exc_info=True)
 
-    def encrypt_data(_input_stream: BytesIO, _password: str) -> BytesIO:
+    def encrypt_data(
+        _input_stream: BytesIO | TextIOBase,
+        _password: str,
+        encoding: str = "utf-8",
+    ) -> BytesIO:
         raise EncryptError("Encryption not supported")
 
     def decrypt_data(

--- a/envex/env_wrapper.py
+++ b/envex/env_wrapper.py
@@ -9,7 +9,8 @@ import os
 import re
 from pathlib import Path
 from io import TextIOBase, BytesIO
-from typing import Any, MutableMapping, Type
+from collections.abc import MutableMapping
+from typing import Any
 
 from envex.env_hvac import SecretsManager
 
@@ -21,7 +22,7 @@ class Env:
     Wrapper around os.environ with .env enhancement` and django support
     """
 
-    _exception: Type[Exception]
+    _exception: type[Exception]
 
     _BOOLEAN_TRUE_STRINGS = frozenset(("1", "en", "ok", "on", "t", "true", "y", "yes"))
     _BOOLEAN_FALSE_STRINGS = frozenset(("", "0", "f", "false", "n", "no", "off"))
@@ -34,7 +35,7 @@ class Env:
         self,
         *args,
         environ: MutableMapping[str, str] | None = None,
-        exception: Type[Exception] | None = None,
+        exception: type[Exception] | None = None,
         readenv: bool = False,
         url: str | None = None,
         token: str | None = None,
@@ -56,7 +57,7 @@ class Env:
         @param password: password to use for decryption
             - if readenv=True, the following additional args may be used
             @param env_file: str name of the environment file (.env or $ENV default)
-            @param search_path: None | Union[List[str], List[Path]], str] path(s) to search for env_file
+            @param search_path: str | Path | list[str | Path] | None path(s) to search for env_file
             @param overwrite: bool whether to overwrite existing environment variables (default=False)
             @param parents: bool whether to search parent directories for env_file (default=False)
             @param update: bool whether to update os.environ with values from env_file (default=False)
@@ -184,7 +185,7 @@ class Env:
         """
         :param kwargs: see load_env
             env_file: str
-            search_path: Union[None, Union[List[str], List[Path]], str]
+            search_path: str | Path | list[str | Path] | None
             overwrite: bool
             parents: bool
             update: bool
@@ -208,11 +209,11 @@ class Env:
             load_stream(stream, environ, overwrite, errors, decrypt, password, encoding)
 
     @property
-    def exception(self) -> Type[Exception]:
+    def exception(self) -> type[Exception]:
         return self._exception
 
     @exception.setter
-    def exception(self, exc: Type[Exception]):
+    def exception(self, exc: type[Exception]):
         self._exception = exc
 
     def get(self, var: str, default=None):

--- a/envex/scripts/envsecrets.py
+++ b/envex/scripts/envsecrets.py
@@ -17,7 +17,6 @@ from collections.abc import Sequence
 from functools import cache
 from pathlib import Path
 from string import Template
-from typing import Union
 
 from envex.dot_env import load_env
 from envex.env_hvac import SecretsManager
@@ -27,7 +26,7 @@ SECRET_MARK = "|"
 
 # noinspection DuplicatedCode
 def read_env(
-    envfile: Union[str, Path, None],
+    envfile: str | Path | None,
     search=None,
     parents=False,
     useenv=False,

--- a/tests/test_env_crypto.py
+++ b/tests/test_env_crypto.py
@@ -1,6 +1,9 @@
 # tests/test_env_crypto.py
 
+import builtins
+import importlib.util
 from io import BytesIO, StringIO
+from pathlib import Path
 
 import pytest
 import envex.env_crypto as env_crypto
@@ -67,6 +70,29 @@ def test_encrypt_data_value_error_raises_encrypt_error(password, monkeypatch):
     with pytest.raises(EncryptError) as e:
         encrypt_data(BytesIO(b"test data"), password)
     assert str(e.value) == "Encryption failed"
+
+
+def test_crypto_import_fallback_raises_clear_errors(monkeypatch):
+    real_import = builtins.__import__
+
+    def blocked_crypto_import(name, globals=None, locals=None, fromlist=(), level=0):
+        if name.startswith("Crypto"):
+            raise ImportError("blocked crypto import")
+        return real_import(name, globals, locals, fromlist, level)
+
+    monkeypatch.setattr(builtins, "__import__", blocked_crypto_import)
+    module_path = Path(env_crypto.__file__)
+    spec = importlib.util.spec_from_file_location(
+        "env_crypto_without_crypto", module_path
+    )
+    module = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    spec.loader.exec_module(module)
+
+    with pytest.raises(module.EncryptError, match="Encryption not supported"):
+        module.encrypt_data(BytesIO(b"test data"), "password", encoding="utf-8")
+    with pytest.raises(module.DecryptError, match="Decryption not supported"):
+        module.decrypt_data(BytesIO(b"test data"), "password")
 
 
 def test_encrypt_empty_data():

--- a/tests/test_load_env.py
+++ b/tests/test_load_env.py
@@ -233,6 +233,20 @@ def test_load_env_accepts_bytes_search_path(tmp_path):
     assert env["FROM_BYTES"] == "ok"
 
 
+def test_load_env_accepts_iterable_search_path(tmp_path):
+    env_file = tmp_path / ".env"
+    env_file.write_text("FROM_ITERABLE=ok\n")
+    search_path = (path for path in [tmp_path])
+
+    env = envex.load_env(
+        search_path=search_path,
+        environ={},
+        update=False,
+    )
+
+    assert env["FROM_ITERABLE"] == "ok"
+
+
 def test_filesystem_path_decode_uses_surrogateescape():
     assert envex.dot_env._decode_filesystem_path(b"\xff")
 

--- a/tests/test_load_env.py
+++ b/tests/test_load_env.py
@@ -220,6 +220,23 @@ def test_load_env_overwrite(monkeypatch, envmap):
     assert env["COMBINED"] == "first-value:alternative-third:fifth-value"
 
 
+def test_load_env_accepts_bytes_search_path(tmp_path):
+    env_file = tmp_path / ".env"
+    env_file.write_text("FROM_BYTES=ok\n")
+
+    env = envex.load_env(
+        search_path=tmp_path.as_posix().encode(),
+        environ={},
+        update=False,
+    )
+
+    assert env["FROM_BYTES"] == "ok"
+
+
+def test_filesystem_path_decode_uses_surrogateescape():
+    assert envex.dot_env._decode_filesystem_path(b"\xff")
+
+
 def test_quoted_value(monkeypatch, envmap):
     monkeypatch.setattr(envex.dot_env, "open_env", dotenv)
     env = envex.load_env(search_path=__file__, environ=envmap)

--- a/tests/test_wrapper.py
+++ b/tests/test_wrapper.py
@@ -422,33 +422,22 @@ def test_env_list(monkeypatch):
     monkeypatch.setattr(envex.dot_env, "open_env", dotenv)
     env = envex.Env(readenv=True)
 
-    result = _extracted_from_test_env_list_5(env, "ALISTOFIPS", 3)
-    assert result == ["::1", "127.0.0.1", "mydomain.com"]
+    assert_env_list_value(env, "ALISTOFIPS", ["::1", "127.0.0.1", "mydomain.com"])
+    assert_env_list_value(
+        env, "ALISTOFIPS", ["::1", "127.0.0.1", "mydomain.com"], via_call=True
+    )
 
-    result = _extracted_from_test_env_list_10(env, "ALISTOFIPS", 3)
-    assert result == ["::1", "127.0.0.1", "mydomain.com"]
-
-    result = _extracted_from_test_env_list_5(env, "LISTOFQUOTEDVALUES", 4)
-    assert result == ["1", "two", "3", "four"]
-
-    result = _extracted_from_test_env_list_10(env, "LISTOFQUOTEDVALUES", 4)
-    assert result == ["1", "two", "3", "four"]
-
-
-def _extracted_from_test_env_list_5(env, arg1, arg2):
-    result = env.list(arg1)
-    return _extracted_from__extracted_from_test_env_list_10_11(result, arg2)
+    expected_quoted_values = ["1", "two", "3", "four"]
+    assert_env_list_value(env, "LISTOFQUOTEDVALUES", expected_quoted_values)
+    assert_env_list_value(
+        env, "LISTOFQUOTEDVALUES", expected_quoted_values, via_call=True
+    )
 
 
-def _extracted_from__extracted_from_test_env_list_10_11(result, arg2):
+def assert_env_list_value(env, key, expected, *, via_call=False):
+    result = env(key, type=list) if via_call else env.list(key)
     assert isinstance(result, list)
-    assert len(result) == arg2
-    return result
-
-
-def _extracted_from_test_env_list_10(env, arg1, arg2):
-    result = env(arg1, type=list)
-    return _extracted_from__extracted_from_test_env_list_10_11(result, arg2)
+    assert result == expected
 
 
 def test_env_iter(monkeypatch):


### PR DESCRIPTION
Summary
- Remove the dead crypto import fallback guard while keeping clear fallback errors covered.
- Replace generated `test_env_list` helper names with a readable assertion helper.
- Modernize typing in touched modules and normalize bytes search path handling.

Linear: [UT-193](https://linear.app/uniquode/issue/UT-193/clean-up-maintenance-debt)