### PR TITLE
UT-195: Harden low-risk correctness edges

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -5,3 +5,4 @@
 - Use `.todo/` for working notes, temporary plans, review handoffs, and other short-lived coordination documents.
 - `.todo/` content is ignored and is not part of the persistent repository.
 - Where an issue prefix is available, use it as a prefix on the pull request title.
+- After a linked PR is merged, check the Linear issue state before updating it; Linear may already have moved it to Done automatically.

--- a/envex/__init__.py
+++ b/envex/__init__.py
@@ -1,5 +1,7 @@
 # -*- coding: utf-8 -*-
 from .dot_env import load_dotenv, load_env
+from .env_crypto import decrypt_data, encrypt_data, DecryptError, EncryptError
+from .env_hvac import SecretsManager
 from .env_wrapper import Env, env
 
 __all__ = (
@@ -7,4 +9,9 @@ __all__ = (
     "load_dotenv",
     "Env",
     "env",
+    "encrypt_data",
+    "decrypt_data",
+    "EncryptError",
+    "DecryptError",
+    "SecretsManager",
 )

--- a/envex/dot_env.py
+++ b/envex/dot_env.py
@@ -10,6 +10,7 @@ from pathlib import Path
 from typing import Any
 
 from .env_crypto import AUTH_MAGIC_BYTES, MAGIC_BYTES, decrypt_data, DecryptError
+from .paths import current_working_dir
 
 __all__ = (
     "load_env",
@@ -343,13 +344,6 @@ def _decode_filesystem_path(path: bytes) -> str:
     return path.decode(fs_encoding, errors="surrogateescape")
 
 
-def _current_working_dir() -> str | None:
-    try:
-        return Path.cwd().resolve(strict=True).as_posix()
-    except FileNotFoundError:
-        return None
-
-
 def load_env(
     env_file: str | Path | None = None,
     search_path: str | bytes | Path | Iterable[str | bytes | Path] | None = None,
@@ -386,7 +380,7 @@ def load_env(
 
     # insert this as a useful default
     if working_dirs:
-        cwd = _current_working_dir()
+        cwd = current_working_dir()
         if cwd is not None:
             environ["CWD"] = cwd
 

--- a/envex/dot_env.py
+++ b/envex/dot_env.py
@@ -99,7 +99,11 @@ def _env_files(
             seen.add(path)
 
     for path in search_path:
-        path = path.resolve()
+        try:
+            path = path.resolve()
+        except FileNotFoundError:
+            record_search(path)
+            continue
         if not path.is_dir():
             path = path.parent
 
@@ -339,6 +343,13 @@ def _decode_filesystem_path(path: bytes) -> str:
     return path.decode(fs_encoding, errors="surrogateescape")
 
 
+def _current_working_dir() -> str | None:
+    try:
+        return Path.cwd().resolve(strict=True).as_posix()
+    except FileNotFoundError:
+        return None
+
+
 def load_env(
     env_file: str | Path | None = None,
     search_path: str | bytes | Path | Iterable[str | bytes | Path] | None = None,
@@ -375,7 +386,9 @@ def load_env(
 
     # insert this as a useful default
     if working_dirs:
-        environ["CWD"] = Path.cwd().resolve(strict=True).as_posix()
+        cwd = _current_working_dir()
+        if cwd is not None:
+            environ["CWD"] = cwd
 
     # determine where to search
     if search_path is None:

--- a/envex/paths.py
+++ b/envex/paths.py
@@ -1,0 +1,11 @@
+# -*- coding: utf-8 -*-
+from pathlib import Path
+
+__all__ = ("current_working_dir",)
+
+
+def current_working_dir() -> str | None:
+    try:
+        return Path.cwd().resolve(strict=True).as_posix()
+    except FileNotFoundError:
+        return None

--- a/envex/scripts/envsecrets.py
+++ b/envex/scripts/envsecrets.py
@@ -18,10 +18,20 @@ from functools import cache
 from pathlib import Path
 from string import Template
 
-from envex.dot_env import load_env
+from envex.dot_env import _current_working_dir, load_env
 from envex.env_hvac import SecretsManager
 
 SECRET_MARK = "|"
+
+
+def _default_search_path(envfile: str | Path | None) -> list[str | Path]:
+    cwd = _current_working_dir()
+    if cwd is not None:
+        return [cwd]
+    if envfile is not None and Path(envfile).is_absolute():
+        return [Path(envfile)]
+    error("current working directory is unavailable; skipping default dotenv search path")
+    return []
 
 
 # noinspection DuplicatedCode
@@ -34,7 +44,7 @@ def read_env(
 ):
     """Read the entire .env file"""
     if search is None:
-        search_path = [Path.cwd()]
+        search_path = _default_search_path(envfile)
     else:
         search_path = set()
         for path in [p.split(",") for p in search]:

--- a/envex/scripts/envsecrets.py
+++ b/envex/scripts/envsecrets.py
@@ -18,14 +18,15 @@ from functools import cache
 from pathlib import Path
 from string import Template
 
-from envex.dot_env import _current_working_dir, load_env
+from envex.dot_env import load_env
 from envex.env_hvac import SecretsManager
+from envex.paths import current_working_dir
 
 SECRET_MARK = "|"
 
 
 def _default_search_path(envfile: str | Path | None) -> list[str | Path]:
-    cwd = _current_working_dir()
+    cwd = current_working_dir()
     if cwd is not None:
         return [cwd]
     if envfile is not None and Path(envfile).is_absolute():

--- a/ruff.toml
+++ b/ruff.toml
@@ -5,8 +5,8 @@ indent-width = 4
 fix = true
 output-format = "full"
 
-# Assume Python 3.10
-target-version = "py310"
+# Assume Python 3.12
+target-version = "py312"
 
 [lint]
 # Enable Pyflakes (`F`) and a subset of the pycodestyle (`E`)  codes by default.

--- a/tests/test_envsecrets_script.py
+++ b/tests/test_envsecrets_script.py
@@ -81,3 +81,24 @@ def test_main_uses_default_output_path(tmp_path, monkeypatch):
     )
 
     assert (tmp_path / "docker.env").read_text().splitlines() == ["PUBLIC=hello"]
+
+
+def test_read_env_uses_absolute_dotenv_when_current_working_dir_is_missing(
+    tmp_path, monkeypatch, capsys
+):
+    dotenv = tmp_path / ".env"
+    dotenv.write_text("PUBLIC=hello\n")
+    monkeypatch.setattr(envsecrets, "_current_working_dir", lambda: None)
+
+    assert envsecrets.read_env(dotenv) == {"PUBLIC": "hello"}
+    assert capsys.readouterr().err == ""
+
+
+def test_read_env_warns_when_default_search_path_is_unavailable(monkeypatch, capsys):
+    monkeypatch.setattr(envsecrets, "_current_working_dir", lambda: None)
+
+    assert envsecrets.read_env(None) == {}
+    assert (
+        "WARNING: current working directory is unavailable; "
+        "skipping default dotenv search path"
+    ) in capsys.readouterr().err

--- a/tests/test_envsecrets_script.py
+++ b/tests/test_envsecrets_script.py
@@ -88,14 +88,14 @@ def test_read_env_uses_absolute_dotenv_when_current_working_dir_is_missing(
 ):
     dotenv = tmp_path / ".env"
     dotenv.write_text("PUBLIC=hello\n")
-    monkeypatch.setattr(envsecrets, "_current_working_dir", lambda: None)
+    monkeypatch.setattr(envsecrets, "current_working_dir", lambda: None)
 
     assert envsecrets.read_env(dotenv) == {"PUBLIC": "hello"}
     assert capsys.readouterr().err == ""
 
 
 def test_read_env_warns_when_default_search_path_is_unavailable(monkeypatch, capsys):
-    monkeypatch.setattr(envsecrets, "_current_working_dir", lambda: None)
+    monkeypatch.setattr(envsecrets, "current_working_dir", lambda: None)
 
     assert envsecrets.read_env(None) == {}
     assert (

--- a/tests/test_load_env.py
+++ b/tests/test_load_env.py
@@ -148,6 +148,39 @@ def test_missing_env_file_does_not_yield_phantom_path(tmp_path):
     assert "PWD" not in env
 
 
+def test_missing_current_working_dir_omits_cwd(tmp_path, monkeypatch):
+    env_file = tmp_path / ".env"
+    env_file.write_text("VALUE=ok\n")
+    monkeypatch.setattr(envex.dot_env, "_current_working_dir", lambda: None)
+
+    env = envex.load_env(search_path=tmp_path, environ={}, update=False)
+
+    assert env["VALUE"] == "ok"
+    assert "CWD" not in env
+    assert env["PWD"] == tmp_path.as_posix()
+
+
+def test_default_search_path_skips_missing_current_working_dir(tmp_path, monkeypatch):
+    env_file = tmp_path / ".env"
+    env_file.write_text("VALUE=ok\n")
+    original_resolve = envex.dot_env.Path.resolve
+
+    def resolve(path, *args, **kwargs):
+        if str(path) == ".":
+            raise FileNotFoundError
+        return original_resolve(path, *args, **kwargs)
+
+    monkeypatch.setattr(envex.dot_env, "_current_working_dir", lambda: None)
+    monkeypatch.setattr(envex.dot_env, "_default_search_path", lambda: [".", tmp_path])
+    monkeypatch.setattr(envex.dot_env.Path, "resolve", resolve)
+
+    env = envex.load_env(environ={}, update=False)
+
+    assert env["VALUE"] == "ok"
+    assert "CWD" not in env
+    assert env["PWD"] == tmp_path.as_posix()
+
+
 def test_missing_env_file_errors_true_raises(tmp_path):
     with pytest.raises(FileNotFoundError):
         envex.load_env(

--- a/tests/test_load_env.py
+++ b/tests/test_load_env.py
@@ -151,7 +151,7 @@ def test_missing_env_file_does_not_yield_phantom_path(tmp_path):
 def test_missing_current_working_dir_omits_cwd(tmp_path, monkeypatch):
     env_file = tmp_path / ".env"
     env_file.write_text("VALUE=ok\n")
-    monkeypatch.setattr(envex.dot_env, "_current_working_dir", lambda: None)
+    monkeypatch.setattr(envex.dot_env, "current_working_dir", lambda: None)
 
     env = envex.load_env(search_path=tmp_path, environ={}, update=False)
 
@@ -170,7 +170,7 @@ def test_default_search_path_skips_missing_current_working_dir(tmp_path, monkeyp
             raise FileNotFoundError
         return original_resolve(path, *args, **kwargs)
 
-    monkeypatch.setattr(envex.dot_env, "_current_working_dir", lambda: None)
+    monkeypatch.setattr(envex.dot_env, "current_working_dir", lambda: None)
     monkeypatch.setattr(envex.dot_env, "_default_search_path", lambda: [".", tmp_path])
     monkeypatch.setattr(envex.dot_env.Path, "resolve", resolve)
 

--- a/tests/test_public_api.py
+++ b/tests/test_public_api.py
@@ -1,0 +1,35 @@
+# -*- coding: utf-8 -*-
+from io import BytesIO
+
+import envex
+from envex.env_crypto import decrypt_data, encrypt_data, DecryptError, EncryptError
+from envex.env_hvac import SecretsManager
+
+
+def test_public_exports_include_core_helpers():
+    assert {
+        "load_env",
+        "load_dotenv",
+        "Env",
+        "env",
+        "encrypt_data",
+        "decrypt_data",
+        "EncryptError",
+        "DecryptError",
+        "SecretsManager",
+    } <= set(envex.__all__)
+
+
+def test_public_exports_reference_core_helpers():
+    assert envex.encrypt_data is encrypt_data
+    assert envex.decrypt_data is decrypt_data
+    assert envex.EncryptError is EncryptError
+    assert envex.DecryptError is DecryptError
+    assert envex.SecretsManager is SecretsManager
+
+
+def test_public_crypto_exports_round_trip():
+    password = "public-api-test-password"
+    encrypted = envex.encrypt_data(BytesIO(b"PUBLIC_API=ok\n"), password)
+
+    assert envex.decrypt_data(encrypted, password).getvalue() == b"PUBLIC_API=ok\n"

--- a/tests/test_shell_vars.py
+++ b/tests/test_shell_vars.py
@@ -2,6 +2,7 @@
 import contextlib
 import io
 
+import pytest
 
 import envex
 
@@ -108,3 +109,37 @@ def test_multi_level_nested(monkeypatch):
     monkeypatch.setattr(envex.dot_env, "open_env", shell_vars_env)
     env = envex.load_env(search_path=".")
     assert env["NESTED_MULTI"] == "actual"
+
+
+def build_reference_chain(length: int, final_value: str = "resolved") -> dict[str, str]:
+    environ = {f"VAR{i}": f"$VAR{i + 1}" for i in range(length)}
+    environ[f"VAR{length}"] = final_value
+    return environ
+
+
+def build_reference_cycle(length: int) -> dict[str, str]:
+    return {f"VAR{i}": f"$VAR{(i + 1) % length}" for i in range(length)}
+
+
+@pytest.mark.parametrize(
+    ("environ", "expected"),
+    [
+        pytest.param(
+            build_reference_chain(envex.dot_env.MAX_RECURSION_DEPTH - 1),
+            "resolved",
+            id="resolves-below-limit",
+        ),
+        pytest.param(
+            build_reference_chain(envex.dot_env.MAX_RECURSION_DEPTH),
+            f"$VAR{envex.dot_env.MAX_RECURSION_DEPTH}",
+            id="stops-at-limit",
+        ),
+        pytest.param(
+            build_reference_cycle(envex.dot_env.MAX_RECURSION_DEPTH),
+            "$VAR0",
+            id="cycle-stops-at-limit",
+        ),
+    ],
+)
+def test_nested_vars_recursion_depth(environ, expected):
+    assert envex.dot_env._process_nested_vars("$VAR0", environ) == expected

--- a/tests/test_shell_vars.py
+++ b/tests/test_shell_vars.py
@@ -121,8 +121,14 @@ def build_reference_cycle(length: int) -> dict[str, str]:
     return {f"VAR{i}": f"$VAR{(i + 1) % length}" for i in range(length)}
 
 
+def write_reference_dotenv(tmp_path, references: dict[str, str]) -> None:
+    lines = ["VALUE=$VAR0"]
+    lines.extend(f"{key}={value}" for key, value in references.items())
+    (tmp_path / ".env").write_text("\n".join(lines))
+
+
 @pytest.mark.parametrize(
-    ("environ", "expected"),
+    ("references", "expected"),
     [
         pytest.param(
             build_reference_chain(envex.dot_env.MAX_RECURSION_DEPTH - 1),
@@ -141,5 +147,9 @@ def build_reference_cycle(length: int) -> dict[str, str]:
         ),
     ],
 )
-def test_nested_vars_recursion_depth(environ, expected):
-    assert envex.dot_env._process_nested_vars("$VAR0", environ) == expected
+def test_nested_vars_recursion_depth(tmp_path, references, expected):
+    write_reference_dotenv(tmp_path, references)
+
+    env = envex.load_env(search_path=tmp_path, environ={}, update=False)
+
+    assert env["VALUE"] == expected


### PR DESCRIPTION
Summary:
- Align Ruff's target Python version with the package runtime floor.
- Export crypto helpers/errors and `SecretsManager` from the top-level package API.
- Harden missing-current-directory handling for dotenv loading and envsecrets defaults.
- Add boundary coverage for nested variable recursion and public API exports.

Linear: [UT-195](https://linear.app/uniquode/issue/UT-195/harden-low-risk-correctness-edges)
Linear: [UT-194](https://linear.app/uniquode/issue/UT-194/align-tooling-python-target)