### PR TITLE
UT-196: Add CLI coverage and cleanup

### DIFF
--- a/envex/dot_env.py
+++ b/envex/dot_env.py
@@ -232,7 +232,7 @@ def _process_env(
 def _process_var_reference(
     var_name: str, environ: MutableMapping[str, str], preserve_missing: bool = False
 ) -> str:
-    """Process a variable reference and return its value or empty string if not found"""
+    """Resolve a variable reference, optionally preserving missing references."""
     if preserve_missing and var_name not in environ:
         return f"${var_name}"
     return environ.get(var_name, "")

--- a/envex/dot_env.py
+++ b/envex/dot_env.py
@@ -16,6 +16,7 @@ __all__ = (
     "load_env",
     "load_stream",
     "load_dotenv",  # alias
+    "substitute_env_vars",
     "update_env",
     "unquote",
 )
@@ -228,12 +229,18 @@ def _process_env(
     return environ
 
 
-def _process_var_reference(var_name: str, environ: MutableMapping[str, str]) -> str:
+def _process_var_reference(
+    var_name: str, environ: MutableMapping[str, str], preserve_missing: bool = False
+) -> str:
     """Process a variable reference and return its value or empty string if not found"""
+    if preserve_missing and var_name not in environ:
+        return f"${var_name}"
     return environ.get(var_name, "")
 
 
-def _process_shell_var(match_obj, environ: MutableMapping[str, str]) -> str:
+def _process_shell_var(
+    match_obj, environ: MutableMapping[str, str], preserve_missing: bool = False
+) -> str:
     """
     Process shell-like variable substitution patterns:
     ${VAR} - Standard variable substitution
@@ -251,7 +258,7 @@ def _process_shell_var(match_obj, environ: MutableMapping[str, str]) -> str:
             var_name, modifier, value = parts
 
             # Process any nested variable references in the value
-            value = _process_nested_vars(value, environ)
+            value = _process_nested_vars(value, environ, preserve_missing)
 
             var_value = _process_var_reference(var_name, environ)
             if modifier == "-" and not var_value or modifier == "+" and var_value:
@@ -265,27 +272,45 @@ def _process_shell_var(match_obj, environ: MutableMapping[str, str]) -> str:
                 return ""
 
     # Standard variable substitution
+    if preserve_missing and var_name not in environ:
+        return match_obj.group(0)
     return _process_var_reference(var_name, environ)
 
 
 MAX_RECURSION_DEPTH = 12
 
 
-def _substitute_vars(value: str, environ: MutableMapping[str, str]) -> str:
-    value = _VAR_BRACES_PATTERN.sub(lambda m: _process_shell_var(m, environ), value)
+def _substitute_vars(
+    value: str, environ: MutableMapping[str, str], preserve_missing: bool = False
+) -> str:
+    value = _VAR_BRACES_PATTERN.sub(
+        lambda m: _process_shell_var(m, environ, preserve_missing), value
+    )
     value = _VAR_NO_BRACES_PATTERN.sub(
-        lambda m: _process_var_reference(m.group(1), environ), value
+        lambda m: _process_var_reference(m.group(1), environ, preserve_missing), value
     )
     return value
 
 
-def _process_nested_vars(value: str, environ: MutableMapping[str, str]) -> str:
+def _process_nested_vars(
+    value: str, environ: MutableMapping[str, str], preserve_missing: bool = False
+) -> str:
     for _ in range(MAX_RECURSION_DEPTH):
-        new_value = _substitute_vars(value, environ)
+        new_value = _substitute_vars(value, environ, preserve_missing)
         if new_value == value:
             break
         value = new_value
     return value
+
+
+def substitute_env_vars(
+    value: str,
+    environ: MutableMapping[str, str],
+    *,
+    preserve_missing: bool = False,
+) -> str:
+    """Resolve dotenv-style variable references in a string."""
+    return _process_nested_vars(value, environ, preserve_missing)
 
 
 def _post_process(environ: MutableMapping[str, str]) -> MutableMapping[str, str]:

--- a/envex/scripts/envcrypt.py
+++ b/envex/scripts/envcrypt.py
@@ -7,6 +7,7 @@ import os
 import sys
 import logging
 import string
+from collections.abc import Sequence
 from io import BytesIO
 from pathlib import Path
 
@@ -52,7 +53,7 @@ def check_password_simple(password: str) -> bool:
     return any((pattern in password.lower() for pattern in repeated_patterns))
 
 
-def main():
+def main(argv: Sequence[str] | None = None) -> None:
     import io
     import argparse
 
@@ -140,7 +141,7 @@ def main():
         "output", nargs="?", default=None, action="store", help="Output file (optional)"
     )
 
-    args = parser.parse_args()
+    args = parser.parse_args(sys.argv[1:] if argv is None else argv)
 
     if not (_password := args.password):
         if args.environ:

--- a/envex/scripts/envcrypt.py
+++ b/envex/scripts/envcrypt.py
@@ -54,7 +54,6 @@ def check_password_simple(password: str) -> bool:
 
 
 def main(argv: Sequence[str] | None = None) -> None:
-    import io
     import argparse
 
     class CustomParser(argparse.ArgumentParser):
@@ -65,23 +64,14 @@ def main(argv: Sequence[str] | None = None) -> None:
             self.exit(2)
 
         def print_usage(self, file=None):
-            text = io.StringIO()
-            self._print_message(self.format_usage(), text)
-            self.print_text(text)
-
-        def print_text(self, text):
-            text.seek(0)
-            for line in text.readlines():
-                logger.info(line.strip())
+            self._print_message(self.format_usage(), file or sys.stderr)
 
         def warning(self, message):
             if message:
                 logger.warning(f"{self.prog}: warning: {message}")
 
         def print_help(self, file=None):
-            text = io.StringIO()
-            super().print_help(file=text)
-            self.print_text(text)
+            self._print_message(self.format_help(), file or sys.stdout)
 
     class CustomHelpFormatter(argparse.ArgumentDefaultsHelpFormatter):
         def __init__(self, *args, **kwargs):

--- a/envex/scripts/envsecrets.py
+++ b/envex/scripts/envsecrets.py
@@ -14,15 +14,14 @@ import argparse
 import re
 import sys
 from collections.abc import Sequence
-from functools import cache
 from pathlib import Path
-from string import Template
 
-from envex.dot_env import load_env
+from envex.dot_env import load_env, substitute_env_vars
 from envex.env_hvac import SecretsManager
 from envex.paths import current_working_dir
 
 SECRET_MARK = "|"
+_SUBSTITUTION_PATTERN = re.compile(r"\$\{|\$[a-zA-Z_][a-zA-Z0-9_]*")
 
 
 def _default_search_path(envfile: str | Path | None) -> list[str | Path]:
@@ -63,34 +62,13 @@ def read_env(
     )
 
 
-@cache
-def cache_regex(rx: str) -> re.Pattern:
-    return re.compile(rx)
-
-
-def env_match(var, regexlist, is_value=False):
-    if regexlist:
-        for regex in regexlist:
-            if (
-                is_value
-                and var == regex
-                or not is_value
-                and cache_regex(regex).match(var)
-            ):
-                break
-        else:
-            return False
-    return True
-
-
 def subst(environ, lines) -> list:
     """post-process the variables using ${substitutions}"""
     data = []
 
     def do_subst(value: str) -> str:
-        if all(v in value for v in ("${", "}")):  # looks like template
-            # ignore anything that doesn't resolve, don't throw an exception.
-            value = Template(value).safe_substitute(environ)
+        if _SUBSTITUTION_PATTERN.search(value):
+            value = substitute_env_vars(value, environ, preserve_missing=True)
         return value
 
     for line in lines:

--- a/envex/scripts/envsecrets.py
+++ b/envex/scripts/envsecrets.py
@@ -63,7 +63,7 @@ def read_env(
 
 
 def subst(environ, lines) -> list:
-    """post-process the variables using ${substitutions}"""
+    """Post-process template values using dotenv-style variable substitution."""
     data = []
 
     def do_subst(value: str) -> str:

--- a/tests/test_env2hvac_script.py
+++ b/tests/test_env2hvac_script.py
@@ -1,4 +1,5 @@
 import logging
+import sys
 
 import pytest
 
@@ -10,6 +11,16 @@ Forbidden = type("Forbidden", (Exception,), {"__module__": "hvac.exceptions"})
 class NoopSecretsManager:
     def __init__(self, **kwargs):
         pass
+
+
+def test_main_supports_console_script_help(monkeypatch, capsys):
+    monkeypatch.setattr(sys, "argv", ["env2hvac", "--help"])
+
+    with pytest.raises(SystemExit) as exc_info:
+        env2hvac.main()
+
+    assert exc_info.value.code == 0
+    assert "usage:" in capsys.readouterr().out
 
 
 def install_fake_secrets_manager(

--- a/tests/test_envcrypt_script.py
+++ b/tests/test_envcrypt_script.py
@@ -1,0 +1,89 @@
+import logging
+
+import pytest
+
+from envex.scripts import envcrypt
+
+
+PASSWORD = "Strong#Pass123"
+
+
+def test_main_supports_console_script_help(caplog):
+    caplog.set_level(logging.INFO)
+
+    with pytest.raises(SystemExit) as exc_info:
+        envcrypt.main(["--help"])
+
+    assert exc_info.value.code == 0
+    assert "usage:" in caplog.text
+
+
+def test_main_requires_operation(tmp_path, caplog):
+    input_file = tmp_path / ".env"
+    input_file.write_text("VALUE=ok\n")
+    caplog.set_level(logging.ERROR)
+
+    with pytest.raises(SystemExit) as exc_info:
+        envcrypt.main(["--password", PASSWORD, str(input_file)])
+
+    assert exc_info.value.code == 3
+    assert "operation to perform" in caplog.text
+
+
+def test_main_rejects_legacy_with_encrypt(tmp_path, caplog):
+    input_file = tmp_path / ".env"
+    input_file.write_text("VALUE=ok\n")
+    output_file = tmp_path / ".env.enc"
+    caplog.set_level(logging.ERROR)
+
+    with pytest.raises(SystemExit) as exc_info:
+        envcrypt.main(
+            [
+                "--encrypt",
+                "--legacy",
+                "--password",
+                PASSWORD,
+                str(input_file),
+                str(output_file),
+            ]
+        )
+
+    assert exc_info.value.code == 3
+    assert "--legacy can only be used with --decrypt" in caplog.text
+
+
+def test_main_encrypts_and_decrypts_files(tmp_path):
+    input_file = tmp_path / ".env"
+    encrypted_file = tmp_path / ".env.enc"
+    decrypted_file = tmp_path / ".env.out"
+    input_file.write_text("VALUE=ok\n")
+
+    envcrypt.main(
+        ["--encrypt", "--password", PASSWORD, str(input_file), str(encrypted_file)]
+    )
+    envcrypt.main(
+        ["--decrypt", "--password", PASSWORD, str(encrypted_file), str(decrypted_file)]
+    )
+
+    assert encrypted_file.read_bytes() != input_file.read_bytes()
+    assert decrypted_file.read_text() == "VALUE=ok\n"
+
+
+def test_main_removes_input_after_successful_conversion(tmp_path):
+    input_file = tmp_path / ".env"
+    encrypted_file = tmp_path / ".env.enc"
+    input_file.write_text("VALUE=ok\n")
+
+    envcrypt.main(
+        [
+            "--encrypt",
+            "--rm",
+            "--password",
+            PASSWORD,
+            str(input_file),
+            str(encrypted_file),
+        ]
+    )
+
+    assert not input_file.exists()
+    assert encrypted_file.exists()

--- a/tests/test_envcrypt_script.py
+++ b/tests/test_envcrypt_script.py
@@ -8,14 +8,12 @@ from envex.scripts import envcrypt
 PASSWORD = "Strong#Pass123"
 
 
-def test_main_supports_console_script_help(caplog):
-    caplog.set_level(logging.INFO)
-
+def test_main_supports_console_script_help(capsys):
     with pytest.raises(SystemExit) as exc_info:
         envcrypt.main(["--help"])
 
     assert exc_info.value.code == 0
-    assert "usage:" in caplog.text
+    assert "usage:" in capsys.readouterr().out
 
 
 def test_main_requires_operation(tmp_path, caplog):

--- a/tests/test_envsecrets_script.py
+++ b/tests/test_envsecrets_script.py
@@ -19,7 +19,15 @@ def test_main_parses_argv_and_writes_env_and_secrets(tmp_path, monkeypatch):
     dotenv = tmp_path / ".env"
     dotenv.write_text("PUBLIC=hello\nSECRET=shh\n")
     template = tmp_path / "template.env"
-    template.write_text("PUBLIC\n|SECRET\nDEFAULT=fallback\n")
+    template.write_text(
+        "PUBLIC\n"
+        "|SECRET\n"
+        "DEFAULT=fallback\n"
+        "COMPOSED=${MISSING:-fallback-$PUBLIC}\n"
+        "NO_BRACES=$PUBLIC\n"
+        "CALLBACK=https://${HOST}/cb\n"
+        "PRICE=cost-$5\n"
+    )
     output = tmp_path / "docker.env"
     captured = []
 
@@ -52,6 +60,10 @@ def test_main_parses_argv_and_writes_env_and_secrets(tmp_path, monkeypatch):
     assert output.read_text().splitlines() == [
         "PUBLIC=hello",
         "DEFAULT=fallback",
+        "COMPOSED=fallback-hello",
+        "NO_BRACES=hello",
+        "CALLBACK=https://${HOST}/cb",
+        "PRICE=cost-$5",
     ]
     assert captured == [
         {

--- a/tests/test_seal_script.py
+++ b/tests/test_seal_script.py
@@ -5,6 +5,16 @@ import pytest
 from envex.scripts import seal
 
 
+def test_main_supports_console_script_help(monkeypatch, capsys):
+    monkeypatch.setattr(sys, "argv", ["seal", "--help"])
+
+    with pytest.raises(SystemExit) as exc_info:
+        seal.main()
+
+    assert exc_info.value.code == 0
+    assert "usage:" in capsys.readouterr().out
+
+
 @pytest.mark.parametrize(
     ("sealed", "expected_status"),
     [


### PR DESCRIPTION
Summary:
- Add envcrypt CLI coverage for help, validation, round-trip conversion, and successful input removal.
- Add help smoke tests for env2hvac and seal console-script entrypoints.
- Remove unused envsecrets regex helpers and route envsecrets template substitution through dotenv-style substitution while preserving unresolved placeholders.

Linear: [UT-196](https://linear.app/uniquode/issue/UT-196/add-cli-coverage-and-clean-envsecrets-helpers)