### PR TITLE
UT-197: Harden systemic CLI policy followups

### DIFF
--- a/envex/scripts/lib/decr_action.py
+++ b/envex/scripts/lib/decr_action.py
@@ -21,6 +21,7 @@ class Decrement(argparse.Action):
     def __call__(self, parser, namespace, values, option_string=None):
         current_value = getattr(namespace, self.dest, self.default or 0)
         try:
-            setattr(namespace, self.dest, current_value - 1)
-        except TypeError:
-            pass
+            next_value = int(current_value) - 1
+        except (TypeError, ValueError) as exc:
+            raise argparse.ArgumentError(self, f"{self.dest} must be an integer") from exc
+        setattr(namespace, self.dest, next_value)

--- a/envex/scripts/lib/log.py
+++ b/envex/scripts/lib/log.py
@@ -46,6 +46,7 @@ def log_set_level(level: int | None = None):
     :return: The loggging level that was set.
     :rtype: int
     """
+    global __current_level
     if level is None:
         level = __default_level
     else:
@@ -55,6 +56,7 @@ def log_set_level(level: int | None = None):
             level = len(__levelIndex) - 1
         level = __levelIndex[level]
     logging.getLogger().setLevel(level)
+    __current_level = level
     return level
 
 

--- a/envex/scripts/seal.py
+++ b/envex/scripts/seal.py
@@ -103,6 +103,7 @@ def main():
 
     except Exception as e:
         logging.error(f"{e.__class__.__name__}: {e}")
+        raise SystemExit(1) from e
 
 
 if __name__ == "__main__":

--- a/tests/test_cli_policy.py
+++ b/tests/test_cli_policy.py
@@ -21,15 +21,16 @@ def test_decrement_rejects_non_numeric_state(capsys):
 
 
 def test_log_set_level_updates_current_level():
-    previous_level = logging.getLogger().level
+    previous_level = script_log.log_get_level(logging.getLogger().level)
     try:
         assert script_log.log_get_level(script_log.log_set_level(4)) == 4
         assert script_log.log_get_level() == 4
         assert script_log.log_get_level(script_log.log_set_level(-1)) == 0
         assert script_log.log_get_level() == 0
+        assert script_log.log_get_level(script_log.log_set_level(999)) == 4
+        assert script_log.log_get_level() == 4
     finally:
-        script_log.log_set_level()
-        logging.getLogger().setLevel(previous_level)
+        script_log.log_set_level(previous_level)
 
 
 def test_seal_exits_nonzero_on_operational_error(monkeypatch, caplog):

--- a/tests/test_cli_policy.py
+++ b/tests/test_cli_policy.py
@@ -1,0 +1,51 @@
+import argparse
+import logging
+import sys
+
+import pytest
+
+from envex.scripts import seal
+from envex.scripts.lib import log as script_log
+from envex.scripts.lib.decr_action import Decrement
+
+
+def test_decrement_rejects_non_numeric_state(capsys):
+    parser = argparse.ArgumentParser(prog="quiet-test")
+    parser.add_argument("--quiet", action=Decrement, dest="level", default="bad")
+
+    with pytest.raises(SystemExit) as exc_info:
+        parser.parse_args(["--quiet"])
+
+    assert exc_info.value.code == 2
+    assert "level must be an integer" in capsys.readouterr().err
+
+
+def test_log_set_level_updates_current_level():
+    previous_level = logging.getLogger().level
+    try:
+        assert script_log.log_get_level(script_log.log_set_level(4)) == 4
+        assert script_log.log_get_level() == 4
+        assert script_log.log_get_level(script_log.log_set_level(-1)) == 0
+        assert script_log.log_get_level() == 0
+    finally:
+        script_log.log_set_level()
+        logging.getLogger().setLevel(previous_level)
+
+
+def test_seal_exits_nonzero_on_operational_error(monkeypatch, caplog):
+    class FakeClient:
+        @property
+        def seal_status(self):
+            raise RuntimeError("status failed")
+
+    monkeypatch.setattr(seal.hvac, "Client", lambda **_kwargs: FakeClient())
+    monkeypatch.setattr(
+        sys, "argv", ["seal", "--address", "http://vault.local", "--token", "token"]
+    )
+    caplog.set_level(logging.ERROR)
+
+    with pytest.raises(SystemExit) as exc_info:
+        seal.main()
+
+    assert exc_info.value.code == 1
+    assert "RuntimeError: status failed" in caplog.text


### PR DESCRIPTION
Summary:
- Make quiet-level decrement failures explicit through argparse errors.
- Keep script log-level bookkeeping in sync with the root logger level.
- Make seal CLI operational errors exit non-zero after logging.
- Add focused policy coverage for those behaviors.

Linear: [UT-197](https://linear.app/uniquode/issue/UT-197/harden-systemic-cli-policy-followups)