### PR TITLE
UT-198: Test maintenance cleanup

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -69,8 +69,14 @@ except ImportError:
 
 
 def pytest_configure(config):
-    config.addinivalue_line("markers", "vault: vault module is available")
-    # Register the slow marker
-    pytest.mark.vault = pytest.mark.skipif(
+    config.addinivalue_line("markers", "vault: requires a local Vault test container")
+
+
+def pytest_collection_modifyitems(config, items):
+    _ = config
+    skip_vault = pytest.mark.skipif(
         not use_hvac, reason="Test skipped because hvac_module is not available"
     )
+    for item in items:
+        if "vault" in item.keywords:
+            item.add_marker(skip_vault)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,6 +1,8 @@
 # -*- coding: utf-8 -*-
 import pytest
 
+VAULT_UNAVAILABLE_REASON = "Test skipped because Vault test dependencies are unavailable"
+
 try:
     import hvac
     from hvac.exceptions import InvalidRequest
@@ -67,6 +69,14 @@ try:
 except ImportError:
     use_hvac = False
 
+    @pytest.fixture(scope="session")
+    def vault():
+        pytest.skip(VAULT_UNAVAILABLE_REASON)
+
+    @pytest.fixture(scope="session")
+    def vault_client():
+        pytest.skip(VAULT_UNAVAILABLE_REASON)
+
 
 def pytest_configure(config):
     config.addinivalue_line("markers", "vault: requires a local Vault test container")
@@ -74,9 +84,7 @@ def pytest_configure(config):
 
 def pytest_collection_modifyitems(config, items):
     _ = config
-    skip_vault = pytest.mark.skipif(
-        not use_hvac, reason="Test skipped because hvac_module is not available"
-    )
+    skip_vault = pytest.mark.skipif(not use_hvac, reason=VAULT_UNAVAILABLE_REASON)
     for item in items:
         if "vault" in item.keywords:
             item.add_marker(skip_vault)

--- a/tests/test_env_crypto.py
+++ b/tests/test_env_crypto.py
@@ -12,20 +12,7 @@ from envex.env_crypto import encrypt_data, decrypt_data, EncryptError, DecryptEr
 
 @pytest.fixture
 def password():
-    # Provide a test password fixture
     return "#pretEnD_stR0ng_pAs$woRd"
-
-
-@pytest.fixture
-def incorrect_password():
-    # Provide an incorrect test password
-    return "wrong_password"
-
-
-@pytest.fixture
-def encrypted_stream_with_invalid_magic_bytes():
-    # Mock BytesIO stream with invalid magic bytes
-    return BytesIO(b"DATA_WITH_INVALID_MAGIC_BYTES")
 
 
 def test_encrypt_data_success(password):
@@ -100,14 +87,14 @@ def test_encrypt_empty_data():
     password = "strongpassword123"
     result = encrypt_data(input_data, password)
     assert isinstance(result, BytesIO)
-    assert len(result.getvalue()) > 0  # Ensure outputs exist even for empty input
+    assert len(result.getvalue()) > 0
 
 
 def test_encrypt_large_data(password):
-    input_data = BytesIO(b"a" * 10**6)  # 1MB of data
+    input_data = BytesIO(b"a" * 10**6)
     result = encrypt_data(input_data, password)
     assert isinstance(result, BytesIO)
-    assert result.getvalue() != b"a" * 10**6  # Ensure data is encrypted
+    assert result.getvalue() != b"a" * 10**6
     assert input_data.getvalue() == decrypt_data(result, password).getvalue()
 
 
@@ -128,8 +115,9 @@ def test_tampered_ciphertext_fails_authentication(password):
     assert str(e.value) == "Incorrect password or invalid data"
 
 
-def test_invalid_magic_bytes(encrypted_stream_with_invalid_magic_bytes, password):
-    # Ensure decryption fails on invalid magic bytes
+def test_invalid_magic_bytes(password):
+    encrypted_stream_with_invalid_magic_bytes = BytesIO(b"DATA_WITH_INVALID_MAGIC_BYTES")
+
     with pytest.raises(DecryptError) as e:
         decrypt_data(encrypted_stream_with_invalid_magic_bytes, password)
     assert "does not look to be encrypted" in str(e.value)
@@ -143,12 +131,12 @@ def test_truncated_authenticated_stream_raises_decrypt_error(password):
     assert "invalid data" in str(e.value)
 
 
-def test_invalid_password(incorrect_password, password):
+def test_invalid_password(password):
     data = b"VALID_ENCRYPTED_DATA"
     encrypted_data = encrypt_data(BytesIO(data), password)
-    # Ensure decryption fails with an incorrect password
+
     with pytest.raises(DecryptError) as e:
-        decrypt_data(encrypted_data, incorrect_password)
+        decrypt_data(encrypted_data, "wrong_password")
     assert "Incorrect password or invalid data" in str(e.value)
 
 
@@ -194,7 +182,6 @@ def test_legacy_cbc_padding_failures_are_generic(password):
 
 
 def test_empty_stream(password):
-    # Test with an empty BytesIO stream
     empty_stream = BytesIO()
     with pytest.raises(DecryptError):
         decrypt_data(empty_stream, password)

--- a/tests/test_env_secrets.py
+++ b/tests/test_env_secrets.py
@@ -4,6 +4,7 @@ from envex import Env
 
 
 @pytest.mark.integration
+@pytest.mark.vault
 def test_vault_secrets(vault):
     env = Env(
         url=vault.get_connection_url(),
@@ -11,27 +12,15 @@ def test_vault_secrets(vault):
         token=vault.root_token,
         engine="kv",
     )
-    assert env is not None
-    assert env.secret_manager is not None
-    assert env.secret_manager.client is not None
-
     client = env.secret_manager.client
     assert client.is_authenticated()
 
-    # test data set up in the vault fixture
     assert env["ABC"] == "123"
     assert env["DEF"] == "456"
-    # other environment variables that have a very high chance of being set
-    assert env["PATH"] is not None
-    assert env["HOME"] is not None
 
     assert env.get("XY_ZZY") is None
 
     env.secret_manager.set_secret("XY_ZZY", "789")
     assert env["XY_ZZY"] == "789"
 
-    secrets = env.secret_manager.list_secrets()
-    assert secrets is not None
-    assert "ABC" in secrets
-    assert "DEF" in secrets
-    assert "XY_ZZY" in secrets
+    assert set(env.secret_manager.list_secrets()) == {"ABC", "DEF", "XY_ZZY"}

--- a/tests/test_load_env.py
+++ b/tests/test_load_env.py
@@ -52,38 +52,51 @@ def test_load_env(monkeypatch, envmap):
     assert env["COMBINED"] == "first-value:third-value:fifth-value"
 
 
-def test_export_command_respects_isolated_environ(monkeypatch, envmap):
+@pytest.mark.parametrize(
+    ("update", "expected_os_value"),
+    [
+        (False, None),
+        (True, "fifth-value"),
+    ],
+)
+def test_export_command_updates_requested_environ(
+    update, expected_os_value, monkeypatch, envmap
+):
     monkeypatch.delenv("FIFTH", raising=False)
     monkeypatch.setattr(envex.dot_env, "open_env", dotenv)
 
-    env = envex.load_env(search_path=__file__, environ=envmap, update=False)
+    env = envex.load_env(search_path=__file__, environ=envmap, update=update)
 
     assert env["FIFTH"] == "fifth-value"
-    assert "FIFTH" not in envex.dot_env.os.environ
+    assert envex.dot_env.os.environ.get("FIFTH") == expected_os_value
 
 
-def test_export_command_updates_os_environ_only_when_requested(monkeypatch, envmap):
-    monkeypatch.delenv("FIFTH", raising=False)
-    monkeypatch.setattr(envex.dot_env, "open_env", dotenv)
-
-    env = envex.load_env(search_path=__file__, environ=envmap, update=True)
-
-    assert env["FIFTH"] == "fifth-value"
-    assert envex.dot_env.os.environ["FIFTH"] == "fifth-value"
-
-
-def test_empty_values_are_preserved(tmp_path):
+@pytest.mark.parametrize(
+    "line",
+    [
+        pytest.param("EMPTY=\n", id="default"),
+        pytest.param("export EMPTY=\n", id="export"),
+    ],
+)
+def test_empty_values_are_preserved(tmp_path, line):
     env_file = tmp_path / ".env"
-    env_file.write_text("EMPTY=\n")
+    env_file.write_text(line)
 
     env = envex.load_env(search_path=tmp_path, environ={}, update=False)
 
     assert env["EMPTY"] == ""
 
 
-def test_empty_values_follow_overwrite_semantics(tmp_path):
+@pytest.mark.parametrize(
+    "line",
+    [
+        pytest.param("EMPTY=\n", id="default"),
+        pytest.param("export EMPTY=\n", id="export"),
+    ],
+)
+def test_empty_values_follow_overwrite_semantics(tmp_path, line):
     env_file = tmp_path / ".env"
-    env_file.write_text("EMPTY=\n")
+    env_file.write_text(line)
 
     preserved = envex.load_env(
         search_path=tmp_path,
@@ -111,27 +124,6 @@ def test_export_empty_value_respects_isolated_environ(tmp_path, monkeypatch):
 
     assert env["EMPTY"] == ""
     assert "EMPTY" not in envex.dot_env.os.environ
-
-
-def test_export_empty_values_follow_overwrite_semantics(tmp_path):
-    env_file = tmp_path / ".env"
-    env_file.write_text("export EMPTY=\n")
-
-    preserved = envex.load_env(
-        search_path=tmp_path,
-        environ={"EMPTY": "existing"},
-        update=False,
-        overwrite=False,
-    )
-    overwritten = envex.load_env(
-        search_path=tmp_path,
-        environ={"EMPTY": "existing"},
-        update=False,
-        overwrite=True,
-    )
-
-    assert preserved["EMPTY"] == "existing"
-    assert overwritten["EMPTY"] == ""
 
 
 def test_missing_env_file_does_not_yield_phantom_path(tmp_path):
@@ -281,7 +273,7 @@ def test_load_env_accepts_iterable_search_path(tmp_path):
 
 
 def test_filesystem_path_decode_uses_surrogateescape():
-    assert envex.dot_env._decode_filesystem_path(b"\xff")
+    assert envex.dot_env._decode_filesystem_path(b"\xff") == "\udcff"
 
 
 def test_quoted_value(monkeypatch, envmap):
@@ -291,16 +283,28 @@ def test_quoted_value(monkeypatch, envmap):
     assert env["SINGLE_QUOTED"] == "a quoted value"
 
 
-def test_load_env_default_search_path_uses_external_caller(tmp_path, monkeypatch):
+@pytest.mark.parametrize(
+    ("loader_expression", "expected_value"),
+    [
+        (
+            "envex.load_env(environ={}, update=False, working_dirs=False)",
+            "direct",
+        ),
+        (
+            "envex.Env(readenv=True, environ={}, update=False, working_dirs=False)",
+            "wrapper",
+        ),
+    ],
+)
+def test_default_search_path_uses_external_caller(
+    tmp_path, monkeypatch, loader_expression, expected_value
+):
     caller_dir = tmp_path / "caller"
     caller_dir.mkdir()
-    (caller_dir / ".env").write_text("FROM_CALLER=direct\n")
+    (caller_dir / ".env").write_text(f"FROM_CALLER={expected_value}\n")
     module_path = caller_dir / "caller_module.py"
     module_path.write_text(
-        "import envex\n"
-        "\n"
-        "def load():\n"
-        "    return envex.load_env(environ={}, update=False, working_dirs=False)\n"
+        f"import envex\n\ndef load():\n    return {loader_expression}\n"
     )
     cwd = tmp_path / "cwd"
     cwd.mkdir()
@@ -309,25 +313,4 @@ def test_load_env_default_search_path_uses_external_caller(tmp_path, monkeypatch
     module = load_module(module_path)
     env = module.load()
 
-    assert env["FROM_CALLER"] == "direct"
-
-
-def test_env_readenv_default_search_path_skips_envex_wrappers(tmp_path, monkeypatch):
-    caller_dir = tmp_path / "caller"
-    caller_dir.mkdir()
-    (caller_dir / ".env").write_text("FROM_CALLER=wrapper\n")
-    module_path = caller_dir / "caller_module.py"
-    module_path.write_text(
-        "import envex\n"
-        "\n"
-        "def load():\n"
-        "    return envex.Env(readenv=True, environ={}, update=False, working_dirs=False)\n"
-    )
-    cwd = tmp_path / "cwd"
-    cwd.mkdir()
-    monkeypatch.chdir(cwd)
-
-    module = load_module(module_path)
-    env = module.load()
-
-    assert env["FROM_CALLER"] == "wrapper"
+    assert env["FROM_CALLER"] == expected_value

--- a/tests/test_shell_vars.py
+++ b/tests/test_shell_vars.py
@@ -55,60 +55,32 @@ NESTED_MULTI=${VAR1:-${VAR2:-${VAR3:-default}}}
     )
 
 
-def test_standard_substitution(monkeypatch):
-    """Test standard variable substitution"""
+@pytest.fixture
+def shell_env(monkeypatch):
     monkeypatch.setattr(envex.dot_env, "open_env", shell_vars_env)
-    env = envex.load_env(search_path=".")
-    assert env["STANDARD"] == "first-value"
+    return envex.load_env(search_path=".", environ={}, update=False)
 
 
-def test_no_braces_substitution(monkeypatch):
-    """Test variable substitution without braces"""
-    monkeypatch.setattr(envex.dot_env, "open_env", shell_vars_env)
-    env = envex.load_env(search_path=".")
-    assert env["NO_BRACES"] == "second-value"
-
-
-def test_default_value(monkeypatch):
-    """Test default value when variable is not set"""
-    monkeypatch.setattr(envex.dot_env, "open_env", shell_vars_env)
-    env = envex.load_env(search_path=".")
-    assert env["DEFAULT_UNSET"] == "default-value"
-    assert env["DEFAULT_SET"] == "first-value"
-
-
-def test_conditional_value(monkeypatch):
-    """Test conditional value when variable is set or not set"""
-    monkeypatch.setattr(envex.dot_env, "open_env", shell_vars_env)
-    env = envex.load_env(search_path=".")
-    assert env["CONDITIONAL_SET"] == "conditional-value"
-    assert env["CONDITIONAL_UNSET"] == ""
-    assert env["CONDITIONAL_EMPTY"] == ""
-
-
-def test_nested_references(monkeypatch):
-    """Test nested variable references"""
-    monkeypatch.setattr(envex.dot_env, "open_env", shell_vars_env)
-    env = envex.load_env(search_path=".")
-    assert env["NESTED"] == "first-value"
-    assert env["NESTED_DEFAULT"] == "second-value"
-    assert env["NESTED_CONDITIONAL"] == "second-value"
-
-
-def test_complex_cases(monkeypatch):
-    """Test complex cases with multiple substitutions"""
-    monkeypatch.setattr(envex.dot_env, "open_env", shell_vars_env)
-    env = envex.load_env(search_path=".")
-    assert env["COMPLEX"] == "prefix-second-value-suffix"
-    assert env["COMPLEX_DEFAULT"] == "second-value-default"
-
-
-def test_multi_level_nested(monkeypatch):
-    """Test multi-level nested variable substitution resolution"""
-
-    monkeypatch.setattr(envex.dot_env, "open_env", shell_vars_env)
-    env = envex.load_env(search_path=".")
-    assert env["NESTED_MULTI"] == "actual"
+@pytest.mark.parametrize(
+    ("key", "expected"),
+    [
+        ("STANDARD", "first-value"),
+        ("NO_BRACES", "second-value"),
+        ("DEFAULT_UNSET", "default-value"),
+        ("DEFAULT_SET", "first-value"),
+        ("CONDITIONAL_SET", "conditional-value"),
+        ("CONDITIONAL_UNSET", ""),
+        ("CONDITIONAL_EMPTY", ""),
+        ("NESTED", "first-value"),
+        ("NESTED_DEFAULT", "second-value"),
+        ("NESTED_CONDITIONAL", "second-value"),
+        ("COMPLEX", "prefix-second-value-suffix"),
+        ("COMPLEX_DEFAULT", "second-value-default"),
+        ("NESTED_MULTI", "actual"),
+    ],
+)
+def test_shell_variable_substitution(shell_env, key, expected):
+    assert shell_env[key] == expected
 
 
 def build_reference_chain(length: int, final_value: str = "resolved") -> dict[str, str]:

--- a/tests/test_wrapper.py
+++ b/tests/test_wrapper.py
@@ -65,20 +65,25 @@ def test_env_wrapper_dict_none_is_unset():
     assert "ARG2" not in env.env
 
 
-def test_env_wrapper_stream_bytes():
-    stream = io.BytesIO(b"ONE=1\nARG2=two\nENABLED=true\n")
+@pytest.mark.parametrize(
+    ("stream", "expected"),
+    [
+        (
+            io.BytesIO(b"ONE=1\nARG2=two\nENABLED=true\n"),
+            {"ONE": "1", "ARG2": "two", "ENABLED": "true"},
+        ),
+        (
+            io.StringIO("ONE=one\nARG2=2\nENABLED=false\n"),
+            {"ONE": "one", "ARG2": "2", "ENABLED": "false"},
+        ),
+    ],
+    ids=["bytes", "text"],
+)
+def test_env_wrapper_streams(stream, expected):
     env = envex.Env(stream, environ={})
-    assert env("ONE") == "1"
-    assert env("ARG2") == "two"
-    assert env("ENABLED") == "true"
 
-
-def test_env_wrapper_stream_text():
-    stream = io.StringIO("ONE=one\nARG2=2\nENABLED=false\n")
-    env = envex.Env(stream, environ={})
-    assert env("ONE") == "one"
-    assert env("ARG2") == "2"
-    assert env("ENABLED") == "false"
+    for key, value in expected.items():
+        assert env(key) == value
 
 
 def test_env_get():
@@ -303,11 +308,11 @@ def test_env_bool_rejects_invalid_strings(value):
 def test_vault_skip_verify_uses_strict_boolean_parsing(
     skip_verify, expected_verify, monkeypatch
 ):
-    class FakeSecretsManager:
-        calls = []
+    calls = []
 
+    class FakeSecretsManager:
         def __init__(self, **kwargs):
-            self.calls.append(kwargs)
+            calls.append(kwargs)
 
     environ = {}
     if skip_verify is not None:
@@ -316,21 +321,21 @@ def test_vault_skip_verify_uses_strict_boolean_parsing(
     monkeypatch.setattr("envex.env_wrapper.SecretsManager", FakeSecretsManager)
     envex.Env(environ=environ, verify=None)
 
-    assert FakeSecretsManager.calls[-1]["verify"] is expected_verify
+    assert calls[-1]["verify"] is expected_verify
 
 
 @pytest.mark.parametrize("verify", [True, False, "/path/to/ca.pem"])
 def test_explicit_vault_verify_overrides_skip_verify(verify, monkeypatch):
-    class FakeSecretsManager:
-        calls = []
+    calls = []
 
+    class FakeSecretsManager:
         def __init__(self, **kwargs):
-            self.calls.append(kwargs)
+            calls.append(kwargs)
 
     monkeypatch.setattr("envex.env_wrapper.SecretsManager", FakeSecretsManager)
     envex.Env(environ={"VAULT_SKIP_VERIFY": "true"}, verify=verify)
 
-    assert FakeSecretsManager.calls[-1]["verify"] == verify
+    assert calls[-1]["verify"] == verify
 
 
 def test_invalid_vault_skip_verify_raises_value_error(monkeypatch):
@@ -444,20 +449,10 @@ def test_env_iter(monkeypatch):
     monkeypatch.setattr(envex.dot_env, "open_env", dotenv)
     env = envex.Env(readenv=True, update=False)
 
-    # test items() itself (returned by __iter__)
-    for var, val in env.items():
-        assert isinstance(var, str)
-        assert isinstance(val, str)
-
-    # test __iter__ via list()
-    for var, val in list(env):
-        assert isinstance(var, str)
-        assert isinstance(val, str)
-
-    # test __iter__ via dict()
-    for var, val in dict(env).items():
-        assert isinstance(var, str)
-        assert isinstance(val, str)
+    assert list(env) == list(env.items())
+    assert dict(env)["DATABASE_URL"] == (
+        "postgresql://username:password@localhost/database_name"
+    )
 
 
 def test_env_exception():
@@ -501,8 +496,6 @@ def test_env_export():
     env.export({k: None for k in values})
     assert not env.is_any_set(list(values.keys()))
 
-    import os
-
     env.set(values)
     env.export()
     for k, v in values.items():
@@ -543,38 +536,33 @@ def test_check_var(monkeypatch):
     env.read_env()
 
     assert env.check_var("DATABASE_URL") != ""
-    pytest.raises(KeyError, env.check_var, "UNDEFINEDVARIABLE")
+    with pytest.raises(KeyError):
+        env.check_var("UNDEFINEDVARIABLE")
     assert env.check_var(None) == ""
 
 
-def test_setdefault_non_none():
-    env = envex.Env(environ={})
-    # Test when value is not None
-    result = env.setdefault("var1", 123)
-    assert result == "123"
-    assert env.env["var1"] == "123"
-    env.setdefault("var1", 543)
-    assert env.env["var1"] == "123"
+@pytest.mark.parametrize(
+    ("initial", "default", "expected_result", "expected_env"),
+    [
+        ({}, 123, "123", {"var": "123"}),
+        ({}, None, None, {}),
+        ({"var": "value"}, None, "value", {"var": "value"}),
+        ({"var": "abc"}, "def", "abc", {"var": "abc"}),
+    ],
+    ids=[
+        "sets-value",
+        "skips-none",
+        "preserves-existing-with-none",
+        "preserves-existing",
+    ],
+)
+def test_setdefault(initial, default, expected_result, expected_env):
+    env = envex.Env(initial, environ={})
 
+    result = env.setdefault("var", default)
 
-def test_setdefault_none():
-    env = envex.Env(environ={})
-
-    result = env.setdefault("var2", None)
-
-    assert result is None
-    assert "var2" not in env.env
-    env.setdefault("var2", 543)
-    assert env.env["var2"] == "543"
-
-
-def test_setdefault_none_preserves_existing_value():
-    env = envex.Env({"var2": "value"}, environ={})
-
-    result = env.setdefault("var2", None)
-
-    assert result == "value"
-    assert env.env["var2"] == "value"
+    assert result == expected_result
+    assert env.env == expected_env
 
 
 def test_set_none_unsets_existing_value():
@@ -594,19 +582,30 @@ def test_set_dict_none_unsets_existing_value():
     assert env.env["var2"] == "123"
 
 
-def test_setdefault_exists():
-    env = envex.Env(environ={})
-    # Test when variable already exists
-    env.env["var3"] = "abc"
-    result = env.setdefault("var3", "def")
-    assert result == "abc"
-    assert env.env["var3"] == "abc"
+@pytest.mark.parametrize(
+    "selector",
+    [
+        pytest.param("plain", id="plain"),
+        pytest.param("environment", id="environment"),
+        pytest.param("file", id="file"),
+    ],
+)
+def test_encrypted_stream_uses_password_selector(password, tmp_path, selector):
+    environ = {}
+    if selector == "environment":
+        environ = {"TEST_PASSWORD": password}
+        password_arg = "$TEST_PASSWORD"
+    elif selector == "file":
+        password_file = tmp_path / "password.txt"
+        password_file.write_text(f"{password}\n")
+        password_arg = f"@{password_file}"
+    else:
+        password_arg = password
 
-
-def test_encrypted_stream_bytes(password):
     data = b"ONE=1\nARG2=two\nENABLED=true\n"
     stream = encrypt_data(io.BytesIO(data), password)
-    env = envex.Env(stream, password=password)
+    env = envex.Env(stream, decrypt=True, password=password_arg, environ=environ)
+
     assert env("ONE") == "1"
     assert env("ARG2") == "two"
     assert env("ENABLED") == "true"
@@ -621,24 +620,27 @@ def test_encrypted_stream_text(password):
     assert env("ENABLED") == "false"
 
 
-def test_encrypted_stream_bytes_env(password):
-    import os
-
-    os.environ["TEST_PASSWORD"] = password
-    data = b"ONE=1\nARG2=two\nENABLED=true\n"
-    stream = encrypt_data(io.BytesIO(data), password)
-    env = envex.Env(stream, decrypt=True, password="$TEST_PASSWORD")
-    assert env("ONE") == "1"
-    assert env("ARG2") == "two"
-    assert env("ENABLED") == "true"
-
-
-def test_encrypted_env_file_uses_plain_env_password(password, tmp_path):
+@pytest.mark.parametrize(
+    "selector",
+    [
+        pytest.param("plain", id="plain"),
+        pytest.param("environment", id="environment"),
+        pytest.param("file", id="file"),
+    ],
+)
+def test_encrypted_env_file_uses_env_password_selector(password, tmp_path, selector):
     write_encrypted_env(tmp_path, password)
+    environ = {"ENV_PASSWORD": password}
+    if selector == "environment":
+        environ = {"ENV_PASSWORD": "$TEST_PASSWORD", "TEST_PASSWORD": password}
+    elif selector == "file":
+        password_file = tmp_path / "password.txt"
+        password_file.write_text(f"{password}\n")
+        environ = {"ENV_PASSWORD": f"@{password_file}"}
 
     env = envex.Env(
         readenv=True,
-        environ={"ENV_PASSWORD": password},
+        environ=environ,
         env_file=".env",
         search_path=tmp_path,
         update=False,
@@ -649,90 +651,47 @@ def test_encrypted_env_file_uses_plain_env_password(password, tmp_path):
     assert env("ENABLED") == "true"
 
 
-def test_encrypted_env_file_uses_indirect_env_password(password, tmp_path):
-    write_encrypted_env(tmp_path, password)
-
-    env = envex.Env(
-        readenv=True,
-        environ={"ENV_PASSWORD": "$TEST_PASSWORD", "TEST_PASSWORD": password},
-        env_file=".env",
-        search_path=tmp_path,
-        update=False,
-    )
-
-    assert env("ONE") == "1"
-    assert env("ARG2") == "two"
-    assert env("ENABLED") == "true"
-
-
-def test_encrypted_env_file_uses_file_env_password(password, tmp_path):
-    write_encrypted_env(tmp_path, password)
-    password_file = tmp_path / "password.txt"
-    password_file.write_text(f"{password}\n")
-
-    env = envex.Env(
-        readenv=True,
-        environ={"ENV_PASSWORD": f"@{password_file}"},
-        env_file=".env",
-        search_path=tmp_path,
-        update=False,
-    )
-
-    assert env("ONE") == "1"
-    assert env("ARG2") == "two"
-    assert env("ENABLED") == "true"
-
-
-def test_plain_env_file_fallback_with_env_password_is_not_corrupted(password, tmp_path):
-    env_file = tmp_path / ".env"
-    env_file.write_text("ONE=1\nARG2=two\nENABLED=true\n")
-
-    env = envex.Env(
-        readenv=True,
-        environ={"ENV_PASSWORD": password},
-        env_file=".env",
-        search_path=tmp_path,
-        update=False,
-    )
-
-    assert env("ONE") == "1"
-    assert env("ARG2") == "two"
-    assert env("ENABLED") == "true"
-
-
-def test_plain_stream_with_env_password_is_not_corrupted(password):
-    stream = io.BytesIO(b"ONE=1\nARG2=two\nENABLED=true\n")
-
-    env = envex.Env(stream, environ={"ENV_PASSWORD": password})
-
-    assert env("ONE") == "1"
-    assert env("ARG2") == "two"
-    assert env("ENABLED") == "true"
-
-
-@pytest.mark.parametrize("key", ["SECG_KEY", "SECF_KEY"])
-def test_plain_stream_magic_prefix_key_with_env_password_is_not_rejected(password, key):
-    stream = io.BytesIO(f"{key}=value\n".encode())
-
-    env = envex.Env(stream, environ={"ENV_PASSWORD": password})
-
-    assert env[key] == "value"
-
-
-@pytest.mark.parametrize("key", ["SECG_KEY", "SECF_KEY"])
-def test_plain_env_file_magic_prefix_key_with_env_password_is_not_rejected(
-    password, tmp_path, key
+@pytest.mark.parametrize("source", ["env-file", "stream"])
+def test_plaintext_fallback_with_env_password_is_not_corrupted(
+    password, tmp_path, source
 ):
-    env_file = tmp_path / ".env"
-    env_file.write_text(f"{key}=value\n")
+    data = "ONE=1\nARG2=two\nENABLED=true\n"
+    if source == "env-file":
+        env_file = tmp_path / ".env"
+        env_file.write_text(data)
+        env = envex.Env(
+            readenv=True,
+            environ={"ENV_PASSWORD": password},
+            env_file=".env",
+            search_path=tmp_path,
+            update=False,
+        )
+    else:
+        env = envex.Env(io.BytesIO(data.encode()), environ={"ENV_PASSWORD": password})
 
-    env = envex.Env(
-        readenv=True,
-        environ={"ENV_PASSWORD": password},
-        env_file=".env",
-        search_path=tmp_path,
-        update=False,
-    )
+    assert env("ONE") == "1"
+    assert env("ARG2") == "two"
+    assert env("ENABLED") == "true"
+
+
+@pytest.mark.parametrize("key", ["SECG_KEY", "SECF_KEY"])
+@pytest.mark.parametrize("source", ["env-file", "stream"])
+def test_plaintext_magic_prefix_key_with_env_password_is_not_rejected(
+    password, tmp_path, key, source
+):
+    data = f"{key}=value\n"
+    if source == "env-file":
+        env_file = tmp_path / ".env"
+        env_file.write_text(data)
+        env = envex.Env(
+            readenv=True,
+            environ={"ENV_PASSWORD": password},
+            env_file=".env",
+            search_path=tmp_path,
+            update=False,
+        )
+    else:
+        env = envex.Env(io.BytesIO(data.encode()), environ={"ENV_PASSWORD": password})
 
     assert env[key] == "value"
 
@@ -764,28 +723,6 @@ def test_decrypt_false_ignores_env_password(password, tmp_path):
     )
 
     assert env.get("ONE") is None
-
-
-def test_explicit_password_file_selector(password, tmp_path):
-    data = b"ONE=1\nARG2=two\nENABLED=true\n"
-    stream = encrypt_data(io.BytesIO(data), password)
-    password_file = tmp_path / "password.txt"
-    password_file.write_text(f"{password}\n")
-
-    env = envex.Env(stream, decrypt=True, password=f"@{password_file}", environ={})
-
-    assert env("ONE") == "1"
-    assert env("ARG2") == "two"
-    assert env("ENABLED") == "true"
-
-
-def test_encrypted_stream_bytes2(password):
-    data = b"ONE=1\nARG2=two\nENABLED=true\n"
-    stream = encrypt_data(io.BytesIO(data), password)
-    env = envex.Env(stream, decrypt=True, password=password)
-    assert env("ONE") == "1"
-    assert env("ARG2") == "two"
-    assert env("ENABLED") == "true"
 
 
 def test_encrypted_stream_invalid_plaintext_fallback_decode_error(password):


### PR DESCRIPTION
## Summary
- Collapse redundant pytest coverage into behavior-oriented parametrized tests.
- Remove duplicate encrypted stream/password-selector tests and single-use crypto fixtures.
- Clean Vault integration categorization so the `vault` marker remains a real pytest marker with collection-time skipping.

## Context
This is test-suite maintenance only; no production code was changed.

Linear: [UT-198](https://linear.app/uniquode/issue/UT-198/maintain-pytest-suite)