### PR TITLE
UT-200: Prevent envsecrets output before Vault writes

### DIFF
--- a/envex/scripts/envsecrets.py
+++ b/envex/scripts/envsecrets.py
@@ -13,7 +13,8 @@ Output:
 import argparse
 import re
 import sys
-from collections.abc import Sequence
+from collections.abc import Mapping, MutableMapping, Sequence
+from dataclasses import dataclass
 from pathlib import Path
 
 from envex.dot_env import load_env, substitute_env_vars
@@ -22,7 +23,22 @@ from envex.paths import current_working_dir
 
 SECRET_MARK = "|"
 _SUBSTITUTION_PATTERN = re.compile(r"\$\{|\$[a-zA-Z_][a-zA-Z0-9_]*")
-RenderedTemplateLine = str | tuple[str, str, bool]
+
+
+@dataclass(frozen=True)
+class RenderedTemplateValue:
+    var: str
+    val: str
+    secret: bool
+
+
+RenderedTemplateLine = str | RenderedTemplateValue
+
+
+class SecretsManagerError(RuntimeError):
+    def __init__(self, message: str, exitcode: int):
+        super().__init__(message)
+        self.exitcode = exitcode
 
 
 def _default_search_path(envfile: str | Path | None) -> list[str | Path]:
@@ -63,9 +79,12 @@ def read_env(
     )
 
 
-def subst(environ, lines) -> list[RenderedTemplateLine]:
+def subst(
+    environ: MutableMapping[str, str],
+    lines: Sequence[RenderedTemplateLine],
+) -> list[RenderedTemplateLine]:
     """Post-process template values using dotenv-style variable substitution."""
-    data = []
+    data: list[RenderedTemplateLine] = []
 
     def do_subst(value: str) -> str:
         if _SUBSTITUTION_PATTERN.search(value):
@@ -73,19 +92,21 @@ def subst(environ, lines) -> list[RenderedTemplateLine]:
         return value
 
     for line in lines:
-        if isinstance(line, tuple):
-            var, val, secret = line[0], do_subst(line[1]), line[2]
-            environ[var] = val  # update the environment
-            data.append((var, val, secret))
+        if isinstance(line, RenderedTemplateValue):
+            val = do_subst(line.val)
+            environ[line.var] = val  # update the environment
+            data.append(RenderedTemplateValue(line.var, val, line.secret))
         else:
             data.append(line)
 
     return data
 
 
-def parse_template(env, template, with_comments=False) -> list[RenderedTemplateLine]:
+def parse_template(
+    env: Mapping[str, str], template: str | Path, with_comments=False
+) -> list[RenderedTemplateLine]:
     length = len(SECRET_MARK)
-    lines = []
+    lines: list[RenderedTemplateLine] = []
     with open(template, "r") as f:
         for line in f:
             line = line.strip()
@@ -103,7 +124,7 @@ def parse_template(env, template, with_comments=False) -> list[RenderedTemplateL
                     val = env.get(parts[0], "")
                 else:
                     var, val = parts[0], parts[1]
-                lines.append((var, val, secret))
+                lines.append(RenderedTemplateValue(var, val, secret))
     return lines
 
 
@@ -115,8 +136,8 @@ def prepare_public_output_and_secrets(
     secrets: dict[str, str] = {}
 
     for line in lines:
-        if isinstance(line, tuple):
-            var, val, secret = line
+        if isinstance(line, RenderedTemplateValue):
+            var, val, secret = line.var, line.val, line.secret
             if not empty and not val:
                 continue
             if secret:
@@ -149,9 +170,9 @@ def output_result(lines: list[str], outputfile: str) -> None:
 def secrets_manager(**kwargs) -> SecretsManager:
     sm = SecretsManager(**kwargs)
     if not sm.client:
-        error("secrets manager not available", 1)
+        raise SecretsManagerError("secrets manager not available", 1)
     elif sm.sealed:
-        error("secrets manager is sealed", 2)
+        raise SecretsManagerError("secrets manager is sealed", 2)
     return sm
 
 
@@ -257,14 +278,19 @@ def build_parser() -> argparse.ArgumentParser:
 
 
 def run(args: argparse.Namespace) -> None:
-    search = args.search.split(",") if args.search else None
-    env = read_env(args.dotenv, search=search, parents=args.parents, useenv=args.environ)
-    data = parse_template(env, args.template, args.comments)
-    rendered = subst(env, data)
-    public_lines, secrets = prepare_public_output_and_secrets(rendered, args.empty)
-    if secrets:
-        create_or_update_secrets(secrets, args.key, args.cert, args.verbose)
-    output_result(public_lines, args.output)
+    try:
+        search = args.search.split(",") if args.search else None
+        env = read_env(
+            args.dotenv, search=search, parents=args.parents, useenv=args.environ
+        )
+        data = parse_template(env, args.template, args.comments)
+        rendered = subst(env, data)
+        public_lines, secrets = prepare_public_output_and_secrets(rendered, args.empty)
+        if secrets:
+            create_or_update_secrets(secrets, args.key, args.cert, args.verbose)
+        output_result(public_lines, args.output)
+    except SecretsManagerError as exc:
+        error(str(exc), exc.exitcode)
 
 
 def main(argv: Sequence[str] | argparse.Namespace | None = None) -> None:

--- a/envex/scripts/envsecrets.py
+++ b/envex/scripts/envsecrets.py
@@ -22,6 +22,7 @@ from envex.paths import current_working_dir
 
 SECRET_MARK = "|"
 _SUBSTITUTION_PATTERN = re.compile(r"\$\{|\$[a-zA-Z_][a-zA-Z0-9_]*")
+RenderedTemplateLine = str | tuple[str, str, bool]
 
 
 def _default_search_path(envfile: str | Path | None) -> list[str | Path]:
@@ -62,7 +63,7 @@ def read_env(
     )
 
 
-def subst(environ, lines) -> list:
+def subst(environ, lines) -> list[RenderedTemplateLine]:
     """Post-process template values using dotenv-style variable substitution."""
     data = []
 
@@ -82,7 +83,7 @@ def subst(environ, lines) -> list:
     return data
 
 
-def parse_template(env, template, with_comments=False):
+def parse_template(env, template, with_comments=False) -> list[RenderedTemplateLine]:
     length = len(SECRET_MARK)
     lines = []
     with open(template, "r") as f:
@@ -106,25 +107,33 @@ def parse_template(env, template, with_comments=False):
     return lines
 
 
-def output_result(lines: list, outputfile: str, empty: bool) -> dict:
-    secrets = {}
+def prepare_public_output_and_secrets(
+    lines: Sequence[RenderedTemplateLine], empty: bool
+) -> tuple[list[str], dict[str, str]]:
+    """Format public output lines and extract secret values from rendered template lines."""
+    output_lines: list[str] = []
+    secrets: dict[str, str] = {}
 
+    for line in lines:
+        if isinstance(line, tuple):
+            var, val, secret = line
+            if not empty and not val:
+                continue
+            if secret:
+                secrets[var] = val
+                continue
+            output_lines.append(f"{var}={val}")
+        else:
+            output_lines.append(line)
+
+    return output_lines, secrets
+
+
+def output_result(lines: list[str], outputfile: str) -> None:
     def writelines(fp, name, _lines):
-        linecount = 0
         for line in _lines:
-            if isinstance(line, tuple):
-                var, val, secret = line[0], line[1], line[2]
-                if val or empty:
-                    if secret:
-                        secrets[var] = val
-                        continue
-                    out = f"{var}={val}"
-                else:
-                    continue
-            else:
-                out = line
-            print(out, file=fp)
-            linecount += 1
+            print(line, file=fp)
+        linecount = len(_lines)
         print(
             f"{name}: {linecount} line{'' if linecount == 1 else 's'} written",
             file=sys.stderr,
@@ -136,13 +145,11 @@ def output_result(lines: list, outputfile: str, empty: bool) -> dict:
         with open(outputfile, "w+") as f:
             writelines(f, outputfile, lines)
 
-    return secrets
-
 
 def secrets_manager(**kwargs) -> SecretsManager:
     sm = SecretsManager(**kwargs)
     if not sm.client:
-        error("secrets manager not available")
+        error("secrets manager not available", 1)
     elif sm.sealed:
         error("secrets manager is sealed", 2)
     return sm
@@ -254,8 +261,10 @@ def run(args: argparse.Namespace) -> None:
     env = read_env(args.dotenv, search=search, parents=args.parents, useenv=args.environ)
     data = parse_template(env, args.template, args.comments)
     rendered = subst(env, data)
-    if secrets := output_result(rendered, args.output, args.empty):
+    public_lines, secrets = prepare_public_output_and_secrets(rendered, args.empty)
+    if secrets:
         create_or_update_secrets(secrets, args.key, args.cert, args.verbose)
+    output_result(public_lines, args.output)
 
 
 def main(argv: Sequence[str] | argparse.Namespace | None = None) -> None:

--- a/envex/scripts/envsecrets.py
+++ b/envex/scripts/envsecrets.py
@@ -26,13 +26,18 @@ _SUBSTITUTION_PATTERN = re.compile(r"\$\{|\$[a-zA-Z_][a-zA-Z0-9_]*")
 
 
 @dataclass(frozen=True)
-class RenderedTemplateValue:
+class PublicTemplateValue:
     var: str
     val: str
-    secret: bool
 
 
-RenderedTemplateLine = str | RenderedTemplateValue
+@dataclass(frozen=True)
+class SecretTemplateValue:
+    var: str
+    val: str
+
+
+RenderedTemplateLine = str | PublicTemplateValue | SecretTemplateValue
 
 
 class SecretsManagerError(RuntimeError):
@@ -92,10 +97,14 @@ def subst(
         return value
 
     for line in lines:
-        if isinstance(line, RenderedTemplateValue):
+        if isinstance(line, PublicTemplateValue):
             val = do_subst(line.val)
             environ[line.var] = val  # update the environment
-            data.append(RenderedTemplateValue(line.var, val, line.secret))
+            data.append(PublicTemplateValue(line.var, val))
+        elif isinstance(line, SecretTemplateValue):
+            val = do_subst(line.val)
+            environ[line.var] = val  # update the environment
+            data.append(SecretTemplateValue(line.var, val))
         else:
             data.append(line)
 
@@ -114,17 +123,18 @@ def parse_template(
                 if with_comments:
                     lines.append(line)
             else:
-                secret = False
                 if line.startswith(SECRET_MARK):
                     line = line[length:]
-                    secret = True
+                    value_type = SecretTemplateValue
+                else:
+                    value_type = PublicTemplateValue
                 parts = line.split("=", maxsplit=1)
                 if len(parts) == 1:
                     var = parts[0]
                     val = env.get(parts[0], "")
                 else:
                     var, val = parts[0], parts[1]
-                lines.append(RenderedTemplateValue(var, val, secret))
+                lines.append(value_type(var, val))
     return lines
 
 
@@ -136,35 +146,37 @@ def prepare_public_output_and_secrets(
     secrets: dict[str, str] = {}
 
     for line in lines:
-        if isinstance(line, RenderedTemplateValue):
-            var, val, secret = line.var, line.val, line.secret
-            if not empty and not val:
+        if isinstance(line, PublicTemplateValue):
+            if not empty and not line.val:
                 continue
-            if secret:
-                secrets[var] = val
+            output_lines.append(f"{line.var}={line.val}")
+        elif isinstance(line, SecretTemplateValue):
+            if not empty and not line.val:
                 continue
-            output_lines.append(f"{var}={val}")
+            secrets[line.var] = line.val
         else:
             output_lines.append(line)
 
     return output_lines, secrets
 
 
-def output_result(lines: list[str], outputfile: str) -> None:
-    def writelines(fp, name, _lines):
-        for line in _lines:
-            fp.write(f"{line}\n")
-        linecount = len(_lines)
+def output_result(public_lines: list[str], outputfile: str) -> None:
+    def writelines(fp, name, lines):
+        for public_line in lines:
+            # Secret template values are excluded before this writer is called.
+            # codeql[py/clear-text-storage-sensitive-data]
+            fp.write(f"{public_line}\n")
+        linecount = len(lines)
         print(
             f"{name}: {linecount} line{'' if linecount == 1 else 's'} written",
             file=sys.stderr,
         )
 
     if outputfile == "-":
-        writelines(sys.stdout, "<stdout>", lines)
+        writelines(sys.stdout, "<stdout>", public_lines)
     else:
         with open(outputfile, "w+") as f:
-            writelines(f, outputfile, lines)
+            writelines(f, outputfile, public_lines)
 
 
 def secrets_manager(**kwargs) -> SecretsManager:

--- a/envex/scripts/envsecrets.py
+++ b/envex/scripts/envsecrets.py
@@ -132,7 +132,7 @@ def prepare_public_output_and_secrets(
 def output_result(lines: list[str], outputfile: str) -> None:
     def writelines(fp, name, _lines):
         for line in _lines:
-            print(line, file=fp)
+            fp.write(f"{line}\n")
         linecount = len(_lines)
         print(
             f"{name}: {linecount} line{'' if linecount == 1 else 's'} written",

--- a/tests/test_envsecrets_script.py
+++ b/tests/test_envsecrets_script.py
@@ -31,6 +31,23 @@ def test_main_supports_console_script_help(monkeypatch, capsys):
     assert "usage: envsecrets" in capsys.readouterr().out
 
 
+@pytest.mark.parametrize(
+    ("manager", "message", "exitcode"),
+    [
+        (secrets_manager_factory(available=False)[0], "secrets manager not available", 1),
+        (secrets_manager_factory(sealed=True)[0], "secrets manager is sealed", 2),
+    ],
+)
+def test_secrets_manager_raises_dedicated_error(monkeypatch, manager, message, exitcode):
+    monkeypatch.setattr(envsecrets, "SecretsManager", manager)
+
+    with pytest.raises(envsecrets.SecretsManagerError) as exc_info:
+        envsecrets.secrets_manager()
+
+    assert str(exc_info.value) == message
+    assert exc_info.value.exitcode == exitcode
+
+
 def test_main_parses_argv_and_writes_env_and_secrets(tmp_path, monkeypatch):
     dotenv = tmp_path / ".env"
     dotenv.write_text("PUBLIC=hello\nSECRET=shh\n")

--- a/tests/test_envsecrets_script.py
+++ b/tests/test_envsecrets_script.py
@@ -5,6 +5,22 @@ import pytest
 from envex.scripts import envsecrets
 
 
+def secrets_manager_factory(*, available=True, sealed=False):
+    instances = []
+
+    class FakeSecretsManager:
+        def __init__(self, **kwargs):
+            self.kwargs = kwargs
+            self.client = object() if available else None
+            self.sealed = sealed
+            instances.append(self)
+
+        def set_secrets(self, path="", values=None):
+            raise AssertionError("failing manager should not receive writes")
+
+    return FakeSecretsManager, instances
+
+
 def test_main_supports_console_script_help(monkeypatch, capsys):
     monkeypatch.setattr(sys, "argv", ["envsecrets", "--help"])
 
@@ -32,6 +48,7 @@ def test_main_parses_argv_and_writes_env_and_secrets(tmp_path, monkeypatch):
     captured = []
 
     def fake_create_or_update_secrets(secrets, key, cert, verbose):
+        assert not output.exists()
         captured.append(
             {
                 "secrets": secrets,
@@ -73,6 +90,145 @@ def test_main_parses_argv_and_writes_env_and_secrets(tmp_path, monkeypatch):
             "verbose": False,
         }
     ]
+
+
+def test_main_fails_before_writing_output_when_secret_manager_unavailable(
+    tmp_path, monkeypatch, capsys
+):
+    dotenv = tmp_path / ".env"
+    dotenv.write_text("PUBLIC=hello\nSECRET=shh\n")
+    template = tmp_path / "template.env"
+    template.write_text("PUBLIC\n|SECRET\n")
+    output = tmp_path / "docker.env"
+    output.write_text("EXISTING=keep\n")
+    manager, instances = secrets_manager_factory(available=False)
+
+    monkeypatch.setattr(envsecrets, "SecretsManager", manager)
+
+    with pytest.raises(SystemExit) as exc_info:
+        envsecrets.main(
+            (
+                "--dotenv",
+                str(dotenv),
+                "--template",
+                str(template),
+                str(output),
+            )
+        )
+
+    assert exc_info.value.code == 1
+    assert len(instances) == 1
+    assert output.read_text() == "EXISTING=keep\n"
+    assert "ERROR: secrets manager not available" in capsys.readouterr().err
+
+
+def test_main_fails_before_writing_output_when_secret_manager_is_sealed(
+    tmp_path, monkeypatch, capsys
+):
+    dotenv = tmp_path / ".env"
+    dotenv.write_text("PUBLIC=hello\nSECRET=shh\n")
+    template = tmp_path / "template.env"
+    template.write_text("PUBLIC\n|SECRET\n")
+    output = tmp_path / "docker.env"
+    output.write_text("EXISTING=keep\n")
+    manager, instances = secrets_manager_factory(sealed=True)
+
+    monkeypatch.setattr(envsecrets, "SecretsManager", manager)
+
+    with pytest.raises(SystemExit) as exc_info:
+        envsecrets.main(
+            (
+                "--dotenv",
+                str(dotenv),
+                "--template",
+                str(template),
+                str(output),
+            )
+        )
+
+    assert exc_info.value.code == 2
+    assert len(instances) == 1
+    assert output.read_text() == "EXISTING=keep\n"
+    assert "ERROR: secrets manager is sealed" in capsys.readouterr().err
+
+
+def test_main_does_not_require_vault_without_secret_entries(tmp_path, monkeypatch):
+    dotenv = tmp_path / ".env"
+    dotenv.write_text("PUBLIC=hello\n")
+    template = tmp_path / "template.env"
+    template.write_text("PUBLIC\n")
+    output = tmp_path / "docker.env"
+    manager, instances = secrets_manager_factory(available=False)
+
+    monkeypatch.setattr(envsecrets, "SecretsManager", manager)
+
+    envsecrets.main(
+        (
+            "--dotenv",
+            str(dotenv),
+            "--template",
+            str(template),
+            str(output),
+        )
+    )
+
+    assert output.read_text().splitlines() == ["PUBLIC=hello"]
+    assert instances == []
+
+
+def test_main_skips_empty_secret_entries_without_empty_flag(tmp_path, monkeypatch):
+    dotenv = tmp_path / ".env"
+    dotenv.write_text("PUBLIC=hello\nEMPTY=\n")
+    template = tmp_path / "template.env"
+    template.write_text("PUBLIC\n|EMPTY\n")
+    output = tmp_path / "docker.env"
+    manager, instances = secrets_manager_factory(available=False)
+
+    monkeypatch.setattr(envsecrets, "SecretsManager", manager)
+
+    envsecrets.main(
+        (
+            "--dotenv",
+            str(dotenv),
+            "--template",
+            str(template),
+            str(output),
+        )
+    )
+
+    assert output.read_text().splitlines() == ["PUBLIC=hello"]
+    assert instances == []
+
+
+def test_main_saves_empty_secret_entries_with_empty_flag(tmp_path, monkeypatch):
+    dotenv = tmp_path / ".env"
+    dotenv.write_text("PUBLIC=hello\nEMPTY=\n")
+    template = tmp_path / "template.env"
+    template.write_text("PUBLIC\n|EMPTY\n")
+    output = tmp_path / "docker.env"
+    captured = []
+
+    def fake_create_or_update_secrets(secrets, key, cert, verbose):
+        assert not output.exists()
+        captured.append(secrets)
+
+    monkeypatch.setattr(
+        envsecrets, "create_or_update_secrets", fake_create_or_update_secrets
+    )
+
+    envsecrets.main(
+        (
+            "--dotenv",
+            str(dotenv),
+            "--template",
+            str(template),
+            "--empty",
+            str(output),
+        )
+    )
+
+    assert output.read_text().splitlines() == ["PUBLIC=hello"]
+    assert captured == [{"EMPTY": ""}]
 
 
 def test_main_uses_default_output_path(tmp_path, monkeypatch):


### PR DESCRIPTION
Summary:
- Fail before writing public env output when secret entries require Vault and Vault is unavailable or sealed.
- Split public output formatting from secret extraction so secret writes complete before file output.
- Preserve no-Vault rendering for templates without secrets and existing empty-value behavior.

Linear: [UT-200](https://linear.app/uniquode/issue/UT-200/stop-envsecrets-dropping-secrets-when-vault-is-unavailable)