### PR TITLE
UT-201: Make CLI inputs fail predictably

### DIFF
--- a/envex/scripts/env2hvac.py
+++ b/envex/scripts/env2hvac.py
@@ -36,6 +36,25 @@ def _load_existing_secrets(sm: SecretsManager, path: str) -> None:
         )
 
 
+def _validate_input_files(files: list[str]) -> list[str]:
+    expanded_files = []
+    for filename in files:
+        expanded = expand(filename)
+        if not os.path.isfile(expanded):
+            fatal(f"{expanded}: input file does not exist", exc_info=False, exitcode=1)
+        try:
+            with open(expanded, "rb"):
+                pass
+        except OSError as exc:
+            fatal(
+                f"{expanded}: input file is not readable: {exc.strerror}",
+                exc_info=False,
+                exitcode=1,
+            )
+        expanded_files.append(expanded)
+    return expanded_files
+
+
 def handler(
     files: list[str],
     url: str | None = None,
@@ -46,6 +65,7 @@ def handler(
     namespace: str | None = None,
     environ: str | None = None,
 ):
+    files = _validate_input_files(files)
     sm = SecretsManager(url=url, token=token, cert=cert, verify=verify)
     if unseal:
         sm.unseal(keys=unseal.split(","), root_token=token)
@@ -61,7 +81,6 @@ def handler(
         path = sm.join(namespace, environ)
         _load_existing_secrets(sm, path)
         for filename in files:
-            filename = expand(filename)
             try:
                 env = envex.Env(
                     readenv=True,

--- a/envex/scripts/envcrypt.py
+++ b/envex/scripts/envcrypt.py
@@ -140,7 +140,7 @@ def main(argv: Sequence[str] | None = None) -> None:
                 logger.error(f"{parser.prog}: {args.environ} is not set or is empty")
                 exit(2)
         elif args.file:
-            _password = Path(args.file).read_text()
+            _password = Path(args.file).read_text().rstrip("\r\n")
         elif sys.stdin.isatty():
             import getpass
 

--- a/tests/test_env2hvac_script.py
+++ b/tests/test_env2hvac_script.py
@@ -155,3 +155,57 @@ def test_handler_logs_success_after_write(tmp_path, monkeypatch, caplog):
         env2hvac.handler([str(env_file)], namespace="myapp", environ="prod")
 
     assert "Added or updated" not in caplog.text
+
+
+def test_handler_fails_when_explicit_input_file_is_missing(tmp_path, monkeypatch, caplog):
+    missing_file = tmp_path / "missing.env"
+    instances = install_fake_secrets_manager(monkeypatch)
+    caplog.set_level(logging.CRITICAL)
+
+    with pytest.raises(SystemExit) as exc_info:
+        env2hvac.handler([str(missing_file)], namespace="myapp", environ="prod")
+
+    assert exc_info.value.code == 1
+    assert instances == []
+    assert f"{missing_file}: input file does not exist" in caplog.text
+
+
+def test_handler_validates_all_input_files_before_writing(tmp_path, monkeypatch, caplog):
+    env_file = tmp_path / ".env"
+    env_file.write_text("PUBLIC=hello\n")
+    missing_file = tmp_path / "missing.env"
+    instances = install_fake_secrets_manager(monkeypatch)
+    caplog.set_level(logging.CRITICAL)
+
+    with pytest.raises(SystemExit) as exc_info:
+        env2hvac.handler(
+            [str(env_file), str(missing_file)], namespace="myapp", environ="prod"
+        )
+
+    assert exc_info.value.code == 1
+    assert instances == []
+    assert f"{missing_file}: input file does not exist" in caplog.text
+
+
+def test_handler_fails_when_explicit_input_file_is_unreadable(
+    tmp_path, monkeypatch, caplog
+):
+    env_file = tmp_path / ".env"
+    env_file.write_text("PUBLIC=hello\n")
+    instances = install_fake_secrets_manager(monkeypatch)
+    real_open = open
+
+    def fake_open(path, *args, **kwargs):
+        if path == str(env_file):
+            raise PermissionError(13, "permission denied", str(env_file))
+        return real_open(path, *args, **kwargs)
+
+    monkeypatch.setattr(env2hvac, "open", fake_open, raising=False)
+    caplog.set_level(logging.CRITICAL)
+
+    with pytest.raises(SystemExit) as exc_info:
+        env2hvac.handler([str(env_file)], namespace="myapp", environ="prod")
+
+    assert exc_info.value.code == 1
+    assert instances == []
+    assert f"{env_file}: input file is not readable" in caplog.text

--- a/tests/test_envcrypt_script.py
+++ b/tests/test_envcrypt_script.py
@@ -67,6 +67,59 @@ def test_main_encrypts_and_decrypts_files(tmp_path):
     assert decrypted_file.read_text() == "VALUE=ok\n"
 
 
+@pytest.mark.parametrize("line_ending", ["\n", "\r\n"])
+def test_main_strips_password_file_line_endings(tmp_path, line_ending):
+    input_file = tmp_path / ".env"
+    encrypted_file = tmp_path / ".env.enc"
+    decrypted_file = tmp_path / ".env.out"
+    password_file = tmp_path / "password.txt"
+    input_file.write_text("VALUE=ok\n")
+    password_file.write_text(f"{PASSWORD}{line_ending}")
+
+    envcrypt.main(
+        ["--encrypt", "--password", PASSWORD, str(input_file), str(encrypted_file)]
+    )
+    envcrypt.main(
+        [
+            "--decrypt",
+            "--file",
+            str(password_file),
+            str(encrypted_file),
+            str(decrypted_file),
+        ]
+    )
+
+    assert decrypted_file.read_text() == "VALUE=ok\n"
+
+
+@pytest.mark.parametrize("trailing_whitespace", [" ", "\t"])
+def test_main_preserves_password_file_trailing_non_line_whitespace(
+    tmp_path, trailing_whitespace
+):
+    input_file = tmp_path / ".env"
+    encrypted_file = tmp_path / ".env.enc"
+    decrypted_file = tmp_path / ".env.out"
+    password_file = tmp_path / "password.txt"
+    password = f"{PASSWORD}{trailing_whitespace}"
+    input_file.write_text("VALUE=ok\n")
+    password_file.write_text(f"{password}\n")
+
+    envcrypt.main(
+        ["--encrypt", "--password", password, str(input_file), str(encrypted_file)]
+    )
+    envcrypt.main(
+        [
+            "--decrypt",
+            "--file",
+            str(password_file),
+            str(encrypted_file),
+            str(decrypted_file),
+        ]
+    )
+
+    assert decrypted_file.read_text() == "VALUE=ok\n"
+
+
 def test_main_removes_input_after_successful_conversion(tmp_path):
     input_file = tmp_path / ".env"
     encrypted_file = tmp_path / ".env.enc"


### PR DESCRIPTION
Summary:

- Validate explicit `env2hvac` input files before Vault setup, unseal, read, or write work.
- Fail missing and unreadable explicit inputs non-zero instead of importing zero values.
- Strip only password-file line endings in `envcrypt --file`, preserving intentional trailing spaces and tabs.
- Add CLI regression coverage for these failure and password-file paths.

Linear: [UT-201](https://linear.app/uniquode/issue/UT-201/make-cli-inputs-fail-predictably)