### PR TITLE
UT-202: Fix crypto magic-prefix and nested env checks

### DIFF
--- a/envex/env_crypto.py
+++ b/envex/env_crypto.py
@@ -2,7 +2,9 @@
 Block data encryption using authenticated AES-256-GCM.
 """
 
+import io
 import logging
+import re
 import secrets
 from io import BytesIO, TextIOBase
 
@@ -18,7 +20,15 @@ SALT_LENGTH = 16
 LEGACY_IV_LENGTH = 16
 GCM_NONCE_LENGTH = 12
 GCM_TAG_LENGTH = 16
+AUTH_CONTAINER_MIN_REMAINDER_LENGTH = SALT_LENGTH + GCM_NONCE_LENGTH + GCM_TAG_LENGTH
+LEGACY_CONTAINER_REMAINDER_HEADER_LENGTH = SALT_LENGTH + LEGACY_IV_LENGTH
 DECRYPT_ERROR_MESSAGE = "Incorrect password or invalid data"
+AUTH_MAGIC_PREFIX = AUTH_MAGIC_BYTES.decode("ascii")
+MAGIC_PREFIX = MAGIC_BYTES.decode("ascii")
+TEXT_PROBE_BYTES = 1024
+# Only direct KEY= lines can collide with the magic bytes at offset 0. Dotenv
+# forms such as "export KEY=..." do not need special handling here.
+_DOTENV_ASSIGNMENT_PREFIX_PATTERN = re.compile(r"^\s*([a-zA-Z_][a-zA-Z0-9_]*)\s*=")
 
 logger = logging.getLogger(__file__)
 
@@ -78,7 +88,14 @@ try:
 
     def _read_stream(input_stream: BytesIO | TextIOBase, encoding: str) -> BytesIO:
         if not isinstance(input_stream, BytesIO):
-            input_stream.seek(0)
+            try:
+                input_stream.seek(0)
+            except io.UnsupportedOperation:
+                logger.warning(
+                    "Input stream %r does not support seek(0); only bytes from the current "
+                    "position will be processed",
+                    input_stream,
+                )
             data = input_stream.read()
             data = data.encode(encoding) if isinstance(data, str) else data
             input_stream = BytesIO(data)
@@ -93,6 +110,59 @@ try:
     def _read_magic(input_stream: BytesIO) -> bytes:
         return input_stream.read(len(MAGIC_BYTES))
 
+    def _remaining_length(input_stream: BytesIO) -> int:
+        """Return remaining bytes for streams normalized to seekable BytesIO."""
+        assert isinstance(input_stream, BytesIO)
+        start_pos = input_stream.tell()
+        return len(input_stream.getbuffer()) - start_pos
+
+    def _has_envex_container_structure(input_stream: BytesIO) -> bool:
+        stream_pos = input_stream.tell()
+        header = _read_magic(input_stream)
+        remaining_length = _remaining_length(input_stream)
+        input_stream.seek(stream_pos)
+
+        if header == AUTH_MAGIC_BYTES:
+            return remaining_length >= AUTH_CONTAINER_MIN_REMAINDER_LENGTH
+        if header == MAGIC_BYTES:
+            if remaining_length < LEGACY_CONTAINER_REMAINDER_HEADER_LENGTH:
+                return False
+            encrypted_length = remaining_length - LEGACY_CONTAINER_REMAINDER_HEADER_LENGTH
+            return encrypted_length > 0 and encrypted_length % AES.block_size == 0
+        return False
+
+    def _looks_like_magic_prefix_dotenv_assignment(
+        input_stream: BytesIO, encoding: str
+    ) -> bool:
+        stream_pos = input_stream.tell()
+        try:
+            input_stream.seek(0)
+            text = input_stream.read(TEXT_PROBE_BYTES).decode(encoding)
+        except UnicodeDecodeError:
+            return False
+        finally:
+            input_stream.seek(stream_pos)
+        newline_index = text.find("\n")
+        line = text if newline_index == -1 else text[:newline_index]
+        match = _DOTENV_ASSIGNMENT_PREFIX_PATTERN.match(line)
+        if match is None:
+            return False
+        key = match.group(1)
+        return key.startswith(f"{AUTH_MAGIC_PREFIX}_") or key.startswith(
+            f"{MAGIC_PREFIX}_"
+        )
+
+    def _is_already_encrypted(input_stream: BytesIO, encoding: str) -> bool:
+        # The stream has already been normalized by _read_stream(), so the
+        # helper checks below can safely preserve position with seek/tell.
+        # Plaintext dotenv keys such as SECG_KEY can look like a container
+        # header. Treat them as plaintext only after a bounded prefix decodes
+        # as text; real containers normally contain binary salt/nonce/tag data.
+        if _looks_like_magic_prefix_dotenv_assignment(input_stream, encoding):
+            return False
+        # For all other cases, rely on envex container structure.
+        return _has_envex_container_structure(input_stream)
+
     def encrypt_data(
         input_stream: BytesIO | TextIOBase, password: str, encoding: str = "utf-8"
     ) -> BytesIO:
@@ -100,15 +170,13 @@ try:
         Encrypt a file using AES-256-GCM with a password-derived key.
         """
         input_stream = _read_stream(input_stream, encoding)
-        first_bytes = _read_magic(input_stream)
-        if first_bytes in (MAGIC_BYTES, AUTH_MAGIC_BYTES):
-            logger.debug("Attempted to encrypt an already encrypted stream")
-            raise EncryptError("This data is already encrypted")
-        input_stream.seek(0)
-
         if not password:
             logger.debug("No or blank password provided")
             raise EncryptError("No or blank password provided")
+        if _is_already_encrypted(input_stream, encoding):
+            logger.debug("Attempted to encrypt an already encrypted stream")
+            raise EncryptError("This data is already encrypted")
+        input_stream.seek(0)
 
         key, salt = generate_key_from_password(password)
 

--- a/envex/env_crypto.py
+++ b/envex/env_crypto.py
@@ -117,9 +117,12 @@ try:
 
     def _has_envex_container_structure(input_stream: BytesIO) -> bool:
         stream_pos = input_stream.tell()
-        header = _read_magic(input_stream)
-        remaining_length = _remaining_length(input_stream)
-        input_stream.seek(stream_pos)
+        try:
+            input_stream.seek(0)
+            header = _read_magic(input_stream)
+            remaining_length = _remaining_length(input_stream)
+        finally:
+            input_stream.seek(stream_pos)
 
         if header == AUTH_MAGIC_BYTES:
             return remaining_length >= AUTH_CONTAINER_MIN_REMAINDER_LENGTH
@@ -153,7 +156,7 @@ try:
 
     def _is_already_encrypted(input_stream: BytesIO, encoding: str) -> bool:
         # The stream has already been normalized by _read_stream(), so the
-        # helper checks below can safely preserve position with seek/tell.
+        # helper checks below can safely probe from offset 0 and restore position.
         # Plaintext dotenv keys such as SECG_KEY can look like a container
         # header. Treat them as plaintext only after a bounded prefix decodes
         # as text; real containers normally contain binary salt/nonce/tag data.

--- a/envex/env_crypto.py
+++ b/envex/env_crypto.py
@@ -92,9 +92,8 @@ try:
                 input_stream.seek(0)
             except io.UnsupportedOperation:
                 logger.warning(
-                    "Input stream %r does not support seek(0); only bytes from the current "
-                    "position will be processed",
-                    input_stream,
+                    "Input stream does not support seek(0); only bytes from the "
+                    "current position will be processed"
                 )
             data = input_stream.read()
             data = data.encode(encoding) if isinstance(data, str) else data

--- a/envex/env_wrapper.py
+++ b/envex/env_wrapper.py
@@ -9,7 +9,7 @@ import os
 import re
 from pathlib import Path
 from io import TextIOBase, BytesIO
-from collections.abc import MutableMapping
+from collections.abc import MutableMapping, Sequence
 from typing import Any
 
 from envex.env_hvac import SecretsManager
@@ -254,17 +254,21 @@ class Env:
 
     def is_all_set(self, *_vars):
         for v in _vars:
-            if isinstance(v, (list, tuple)):
-                return self.is_all_set(*v)
-            if not self.is_set(v):
+            # Expand list/tuple-like containers without consuming generators
+            # or treating unordered mappings/sets as positional arguments.
+            if isinstance(v, Sequence) and not isinstance(v, (str, bytes)):
+                if not self.is_all_set(*v):
+                    return False
+            elif not self.is_set(v):
                 return False
         return True
 
     def is_any_set(self, *_vars):
         for v in _vars:
-            if isinstance(v, (list, tuple)):
-                return self.is_any_set(*v)
-            if self.is_set(v):
+            if isinstance(v, Sequence) and not isinstance(v, (str, bytes)):
+                if self.is_any_set(*v):
+                    return True
+            elif self.is_set(v):
                 return True
         return False
 

--- a/tests/test_env_crypto.py
+++ b/tests/test_env_crypto.py
@@ -64,6 +64,16 @@ def test_encrypt_data_already_encrypted(password):
         encrypt_data(input_enc, password)
 
 
+def test_encrypt_data_rejects_already_encrypted_input_from_current_position(password):
+    input_enc = encrypt_data(BytesIO(b"Some Test data data"), password)
+    input_enc.seek(1)
+
+    with pytest.raises(EncryptError):
+        encrypt_data(input_enc, password)
+
+    assert input_enc.tell() == 1
+
+
 def test_encrypt_data_rejects_assignment_looking_authenticated_output(
     password, monkeypatch
 ):

--- a/tests/test_env_crypto.py
+++ b/tests/test_env_crypto.py
@@ -2,7 +2,7 @@
 
 import builtins
 import importlib.util
-from io import BytesIO, StringIO
+from io import BytesIO, StringIO, UnsupportedOperation
 from pathlib import Path
 
 import pytest
@@ -34,6 +34,22 @@ def test_encrypt_decrypt_unicode_(password):
     assert result.getvalue().decode("utf-8") == test_string
 
 
+def test_encrypt_data_accepts_non_seekable_text_stream(password):
+    class NonSeekableTextStream:
+        def __init__(self, value):
+            self._stream = StringIO(value)
+
+        def seek(self, *_args):
+            raise UnsupportedOperation("not seekable")
+
+        def read(self):
+            return self._stream.read()
+
+    encrypted = encrypt_data(NonSeekableTextStream("VALUE=ok\n"), password)
+
+    assert decrypt_data(encrypted, password).getvalue() == b"VALUE=ok\n"
+
+
 def test_encrypt_data_no_password():
     input_data = BytesIO(b"test data")
     password = ""
@@ -46,6 +62,60 @@ def test_encrypt_data_already_encrypted(password):
     input_enc = encrypt_data(input_data, password)
     with pytest.raises(EncryptError):
         encrypt_data(input_enc, password)
+
+
+def test_encrypt_data_rejects_assignment_looking_authenticated_output(
+    password, monkeypatch
+):
+    def token_bytes(size):
+        if size == env_crypto.SALT_LENGTH:
+            return b"=\n" + b"s" * (size - 2)
+        if size == env_crypto.GCM_NONCE_LENGTH:
+            return b"n" * size
+        return b"x" * size
+
+    monkeypatch.setattr(env_crypto.secrets, "token_bytes", token_bytes)
+    encrypted = encrypt_data(BytesIO(b"Some Test data data"), password)
+
+    assert encrypted.getvalue().startswith(b"SECG=\n")
+    with pytest.raises(EncryptError):
+        encrypt_data(encrypted, password)
+
+
+def test_encrypt_data_rejects_assignment_looking_output_with_wrong_password(
+    password, monkeypatch
+):
+    def token_bytes(size):
+        if size == env_crypto.SALT_LENGTH:
+            return b"_KEY=value\n" + b"s" * (size - 11)
+        if size == env_crypto.GCM_NONCE_LENGTH:
+            return b"n" * size
+        return b"x" * size
+
+    monkeypatch.setattr(env_crypto.secrets, "token_bytes", token_bytes)
+    encrypted = encrypt_data(BytesIO(b"Some Test data data"), password)
+
+    assert encrypted.getvalue().startswith(b"SECG_KEY=value\n")
+    with pytest.raises(EncryptError):
+        encrypt_data(encrypted, "wrong-password")
+
+
+@pytest.mark.parametrize(
+    "line_prefix,key",
+    [
+        ("", "SECG_KEY"),
+        ("", "SECF_KEY"),
+        ("  ", "SECG_KEY"),
+    ],
+)
+def test_encrypt_data_accepts_plaintext_dotenv_magic_prefix_keys(
+    password, line_prefix, key
+):
+    # This length makes both magic prefixes structurally plausible containers.
+    input_data = f"{line_prefix}{key}={'x' * 42}\n".encode()
+    encrypted = encrypt_data(BytesIO(input_data), password)
+
+    assert decrypt_data(encrypted, password).getvalue() == input_data
 
 
 def test_encrypt_data_value_error_raises_encrypt_error(password, monkeypatch):
@@ -148,6 +218,13 @@ def legacy_encrypt_data(data: bytes, password: str) -> BytesIO:
     return BytesIO(
         env_crypto.MAGIC_BYTES + salt + iv + cipher.encrypt(env_crypto._pad(data))
     )
+
+
+def test_encrypt_data_rejects_legacy_encrypted_input(password):
+    encrypted_data = legacy_encrypt_data(b"LEGACY_ENCRYPTED_DATA", password)
+
+    with pytest.raises(EncryptError):
+        encrypt_data(encrypted_data, password)
 
 
 def test_legacy_cbc_decryption_remains_supported(password):

--- a/tests/test_wrapper.py
+++ b/tests/test_wrapper.py
@@ -502,6 +502,39 @@ def test_env_export():
         assert os.environ[k] == str(v)
 
 
+def test_is_all_set_checks_remaining_args_after_nested_collection():
+    env = envex.Env({"A": "1"}, environ={})
+
+    assert not env.is_all_set(["A"], "B")
+
+    env.set("B", "2")
+
+    assert env.is_all_set(["A"], "B")
+
+
+def test_is_any_set_checks_remaining_args_after_nested_collection():
+    env = envex.Env({"A": "1"}, environ={})
+
+    assert env.is_any_set(["missing"], "A")
+    assert not env.is_any_set(["missing"], "also_missing")
+
+
+def test_is_set_helpers_recurse_into_sequence_collections():
+    env = envex.Env({"A": "1", "B": "2"}, environ={})
+
+    assert env.is_all_set(("A", "B"))
+    assert not env.is_all_set(("A", "missing"))
+    assert env.is_any_set(("missing", "A"))
+    assert not env.is_any_set(("missing", "also_missing"))
+
+
+def test_is_set_helpers_do_not_consume_generators_as_nested_vars():
+    env = envex.Env({"A": "1", "B": "2"}, environ={})
+
+    assert not env.is_all_set(key for key in ["A", "B"])
+    assert not env.is_any_set(key for key in ["missing", "B"])
+
+
 def test_env_export_none_removes_process_env_without_keyerror(monkeypatch):
     monkeypatch.setenv("REMOVE_ME", "value")
     env = envex.Env({"REMOVE_ME": "value"}, environ={})


### PR DESCRIPTION
Summary:

- Allow plaintext dotenv assignments beginning with `SECG_` or `SECF_` keys to be encrypted while keeping real envex containers protected from re-encryption.
- Tighten encrypted-container detection for authenticated and legacy payloads, including assignment-looking encrypted bytes.
- Make `Env.is_all_set()` and `Env.is_any_set()` continue after nested sequence inputs without consuming generators or unordered iterables.

Linear: [UT-202](https://linear.app/uniquode/issue/UT-202/fix-crypto-magic-prefix-and-nested-env-checks)