### PR TITLE
UT-203: Harden Vault setup and seal handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ### v5.0.0
 
-- ⚠️ BREAKING CHANGE: encrypted files now use authenticated AES-256-GCM. Files encrypted by envex 5.0.0 or later cannot be decrypted by envex 4.x or older. The new format is properly HMAC protected.
+- ⚠️ BREAKING CHANGE: encrypted files now use authenticated AES-256-GCM. Files encrypted by envex 5.0.0 or later cannot be decrypted by envex 4.x or older. The new format validates encrypted data with a GCM authentication tag.
 - Legacy AES-CBC files can be migrated with
   - `envcrypt --decrypt --legacy ...`, followed by
   - `envcrypt --encrypt ...`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,9 +2,11 @@
 
 ### v5.0.0
 
-- ⚠️ BREAKING CHANGE ⚠️: encrypted files now use authenticated AES-256-GCM. Files encrypted by envex 5.0.0 or later cannot be decrypted by envex 4.x or older.
-- Legacy AES-CBC files can be migrated with `envcrypt --decrypt --legacy ...` followed by `envcrypt --encrypt ...`.
-- ⚠️ BREAKING CHANGE ⚠️: `SecretsManager.base_path` and `SecretsManager.path()` now use logical KV v2 paths. Direct `SecretsManager` users should use `mount_point` for the Vault secrets engine mount.
+- ⚠️ BREAKING CHANGE: encrypted files now use authenticated AES-256-GCM. Files encrypted by envex 5.0.0 or later cannot be decrypted by envex 4.x or older. The new format is properly HMAC protected.
+- Legacy AES-CBC files can be migrated with
+  - `envcrypt --decrypt --legacy ...`, followed by
+  - `envcrypt --encrypt ...`.
+- ⚠️ BREAKING CHANGE: `SecretsManager.base_path` and `SecretsManager.path()` now use logical KV v2 paths. Direct `SecretsManager` users should use `mount_point` for the Vault secrets engine mount.
 - Vault secret reads, writes, and deletes now use hvac's KV v2 API.
 - Vault client certificate configuration now supports either a combined PEM file or separate certificate/key files.
 - `SecretsManager.set_secrets(path, values={})` is non-destructive; use `delete_secrets(path)` to delete a secret document.
@@ -13,6 +15,12 @@
 - `Env.int()` now parses signed integer strings and raises `ValueError` for malformed non-empty values.
 - Extra `Env(...)` keyword environment values now apply after loader and Vault options.
 - Dotenv parsing now preserves empty values, handles missing files explicitly, and raises `DecryptError` for encrypted-looking streams that fail to decrypt.
+
+#### Fixes
+
+- Hardened Vault TLS defaults, seal status, and unseal behavior.
+- `seal --help` now works without optional Vault dependencies installed.
+- Improved encrypted/plaintext dotenv detection around envex magic prefixes and wrong passwords.
 
 ### v4.4.0
 
@@ -40,7 +48,7 @@
 
 ### v4.0.0
 
-- :warning: BREAKING CHANGE: additional kwargs passed to Env() are no longer added to the env if readenv=False. This is probably of no consequence as it is a (mis?)feature that was rarely (if ever) used.
+- ⚠️ BREAKING CHANGE: additional kwargs passed to Env() are no longer added to the env if readenv=False. This is probably of no consequence as it is a (mis?)feature that was rarely (if ever) used.
 - Bugfix: dicts passed in *args the Env() are now correctly converted to str->str mappings.
 - Feature: Env can now take BytesIO and StringIO objects in Env(*args). Since these are immediate objects, they are handled as priority variables, different to variables set via `.env` files in that they overwrite existing variables by default. Explicitly using the overwrite=False changes this behaviour.
 - Warning: To provide support for different types of streams, environment files are now handled internally as bytes. However, before evaluation they are converted via an encoding parameter that defaults to "utf-8".

--- a/envex/dot_env.py
+++ b/envex/dot_env.py
@@ -592,6 +592,8 @@ def _first_dotenv_assignment_key(stream: BytesIO, encoding: str) -> str | None:
             match = _DOTENV_ASSIGNMENT_PREFIX_PATTERN.match(line)
             return match.group(1) if match is not None else None
     except UnicodeDecodeError:
+        # Do not skip binary data looking for a later KEY= line: encrypted bytes
+        # can contain arbitrary dotenv-looking fragments after the header.
         return None
     finally:
         stream.seek(stream_pos)

--- a/envex/dot_env.py
+++ b/envex/dot_env.py
@@ -31,7 +31,14 @@ DEFAULT_ENCODING = "utf-8"
 _MODIFIER_PATTERN = re.compile(r":([-+])")
 _VAR_BRACES_PATTERN = re.compile(r"\${([^{}]+)}")
 _VAR_NO_BRACES_PATTERN = re.compile(r"\$([a-zA-Z_][a-zA-Z0-9_]*)")
-_DOTENV_ASSIGNMENT_PREFIX_PATTERN = re.compile(r"[a-zA-Z_][a-zA-Z0-9_]*\s*=")
+_DOTENV_ASSIGNMENT_PREFIX_PATTERN = re.compile(r"^\s*([a-zA-Z_][a-zA-Z0-9_]*)\s*=")
+# Only keys that use the envex magic header plus "_" can be rescued as
+# plaintext after decryption fails. Broader KEY= matching can be produced by
+# random encrypted bytes and would hide wrong-password/corrupt-container errors.
+_MAGIC_DOTENV_KEY_PREFIXES = (
+    f"{AUTH_MAGIC_BYTES.decode('ascii')}_",
+    f"{MAGIC_BYTES.decode('ascii')}_",
+)
 _PACKAGE_ROOT = Path(__file__).resolve().parent
 
 
@@ -565,7 +572,7 @@ def _load_stream(
             stream.seek(stream_pos)
             if encrypted_header and (
                 _is_encrypted_env_path(env_path)
-                or not _looks_like_plaintext_dotenv(stream, encoding)
+                or not _looks_like_magic_header_plaintext_dotenv(stream, encoding)
             ):
                 raise
     return _process_stream(stream, environ, overwrite, errors, encoding, env_path)
@@ -575,15 +582,36 @@ def _is_encrypted_env_path(env_path: Path | None) -> bool:
     return env_path is not None and env_path.name.endswith(ENCRYPTED_EXT)
 
 
-def _looks_like_plaintext_dotenv(stream: BytesIO, encoding: str) -> bool:
+def _first_dotenv_assignment_key(stream: BytesIO, encoding: str) -> str | None:
     stream_pos = stream.tell()
     try:
-        line = stream.readline().decode(encoding).strip()
+        while line := stream.readline():
+            line = line.decode(encoding).strip()
+            if not line or line.startswith("#"):
+                continue
+            match = _DOTENV_ASSIGNMENT_PREFIX_PATTERN.match(line)
+            return match.group(1) if match is not None else None
     except UnicodeDecodeError:
-        return False
+        return None
     finally:
         stream.seek(stream_pos)
-    return bool(_DOTENV_ASSIGNMENT_PREFIX_PATTERN.match(line))
+    return None
+
+
+def _looks_like_plaintext_dotenv(stream: BytesIO, encoding: str) -> bool:
+    return _first_dotenv_assignment_key(stream, encoding) is not None
+
+
+def _is_magic_header_dotenv_key(key: str) -> bool:
+    return key.startswith(_MAGIC_DOTENV_KEY_PREFIXES)
+
+
+def _looks_like_magic_header_plaintext_dotenv(stream: BytesIO, encoding: str) -> bool:
+    # This stricter rescue only applies when the stream begins with envex magic
+    # bytes and the first real dotenv key follows the documented collision
+    # convention, such as SECG_KEY=....
+    key = _first_dotenv_assignment_key(stream, encoding)
+    return key is not None and _is_magic_header_dotenv_key(key)
 
 
 load_dotenv = load_env

--- a/envex/env_hvac.py
+++ b/envex/env_hvac.py
@@ -29,6 +29,27 @@ def expand(path: str):
     return os.path.expandvars(os.path.expanduser(path))
 
 
+def _vault_verify_from_env() -> bool | str:
+    cacert = os.getenv("VAULT_CACERT")
+    if cacert:
+        return expand(cacert)
+
+    capath = os.getenv("VAULT_CAPATH")
+    if capath:
+        capath = expand(capath)
+        # requests accepts a CA bundle file or an OpenSSL-hashed CA directory.
+        # Prefer honoring a file-valued VAULT_CAPATH over falling back to system
+        # CAs, which would silently weaken a pinned trust configuration.
+        if os.path.isfile(capath) or os.path.isdir(capath):
+            return capath
+        raise ValueError(
+            f"VAULT_CAPATH={capath!r} must point to a CA bundle file "
+            "or CA certificate directory"
+        )
+
+    return True
+
+
 def read_pem(variable: str, is_key: bool = False):
     """
     Get the path from the given environment variable if it points to a valid PEM file.
@@ -51,7 +72,7 @@ class SecretsManager:
         url: str | None = None,
         token: str | None = None,
         cert=None,
-        verify: bool | str = True,
+        verify: bool | str | None = None,
         base_path: str | None = None,
         engine: str | None = None,
         mount_point: str | None = None,
@@ -66,8 +87,10 @@ class SecretsManager:
         :param token (str): Authentication token to include in requests sent to Vault.
         :param cert tuple(cert, key): Certificates for use in requests sent to the Vault instance.
             This should be a tuple with the certificate and then key.
-        :param verify: (Bool | str) Either a boolean to indicate whether TLS verification should be performed
-            when sending requests to Vault, or a string path of the CA bundle to use for verification.
+        :param verify: (Bool | str | None) Either a boolean to indicate whether TLS verification should be
+            performed when sending requests to Vault, a string path of the CA bundle or OpenSSL-hashed CA
+            directory to use for verification, or None to derive verification from VAULT_CACERT, then a
+            VAULT_CAPATH CA directory, then True.
             See https://docs.python-requests.org/en/master/user/advanced/#ssl-cert-verification.
         :param timeout (int): The timeout value for requests sent to Vault.
         :param proxies (dict): Proxies to use when performing requests.
@@ -77,8 +100,8 @@ class SecretsManager:
         :param namespace (str): Optional Vault Namespace.
         :param kwargs (dict): Additional parameters to pass to the adapter constructor.
         """
-        if verify in (True, None):
-            verify = os.getenv("VAULT_CACERT") or True
+        if verify is None:
+            verify = _vault_verify_from_env()
         if isinstance(verify, str):
             verify = expand(verify)
         if cert is None:
@@ -259,20 +282,24 @@ class SecretsManager:
             yield from self.secrets.keys()
 
     def seal(self):
-        if self.client:
-            response = self.client.sys.seal()
+        # Seal/status/unseal operations must work before authentication succeeds:
+        # a sealed Vault can reject authenticated checks until unseal keys are submitted.
+        if self._client:
+            response = self._client.sys.seal()
             return response["sealed"]
         return None
 
     def unseal(self, keys: list, root_token: str | None):
-        if self.client:
-            response = self.client.sys.submit_unseal_keys(keys, root_token)
+        # Intentionally bypasses self.client so unseal can run while Vault is sealed.
+        if self._client:
+            response = self._client.sys.submit_unseal_keys(keys, root_token)
             return not response["sealed"]
         return None
 
     @property
     def sealed(self) -> bool | None:
-        if self.client:
-            response = self.client.seal_status
+        # Intentionally bypasses self.client so status works before authentication.
+        if self._client:
+            response = self._client.seal_status
             return response["sealed"]
         return None

--- a/envex/env_wrapper.py
+++ b/envex/env_wrapper.py
@@ -40,7 +40,7 @@ class Env:
         url: str | None = None,
         token: str | None = None,
         cert=None,
-        verify: bool | str | None = True,
+        verify: bool | str | None = None,
         base_path: str | None = None,
         engine: str | None = None,
         mount_point: str | None = None,
@@ -67,8 +67,8 @@ class Env:
         @param token: (optional) vault token, default is $VAULT_TOKEN or ~/.vault-token
         @param cert: (optional) tuple (cert, key) or str path to client cert/key files
         @param verify: (optional) bool | str | None whether to verify server cert,
-            set ca cert path, or derive verification from VAULT_SKIP_VERIFY when
-            None (default=True)
+            set ca cert path, or derive verification from VAULT_SKIP_VERIFY and
+            Vault CA environment when None (default=None)
         @param base_path: (optional) str base path for secrets (default=None)
         @param engine: (optional) str vault secrets engine (default=None)
         @param mount_point: (optional) str vault secrets mount point (default=None, determined by engine)
@@ -111,11 +111,15 @@ class Env:
         self.read_streams(*streams, **load_env_kwargs)
         self.set(kwargs)
         self.env_source = self._resolve_env_source() == "env"
-        vault_verify = (
-            verify
-            if verify is not None
-            else not self.bool("VAULT_SKIP_VERIFY", default=False)
-        )
+        # Explicit verify wins. When omitted, VAULT_SKIP_VERIFY=true becomes an
+        # explicit False; otherwise SecretsManager derives VAULT_CACERT /
+        # VAULT_CAPATH / True in that order.
+        if verify is None:
+            vault_verify = (
+                False if self.bool("VAULT_SKIP_VERIFY", default=False) else None
+            )
+        else:
+            vault_verify = verify
         self.secret_manager = SecretsManager(
             url=url,
             token=token,

--- a/envex/scripts/env2hvac.py
+++ b/envex/scripts/env2hvac.py
@@ -67,17 +67,19 @@ def handler(
 ):
     files = _validate_input_files(files)
     sm = SecretsManager(url=url, token=token, cert=cert, verify=verify)
-    if unseal:
-        sm.unseal(keys=unseal.split(","), root_token=token)
-
-    client = sm.client
-    if client is None:
-        fatal("Can't connect or authenticate with Vault", exc_info=False, exitcode=1)
-
-    if client.seal_status["sealed"]:
-        fatal("Vault is currently sealed", exc_info=False, exitcode=4)
-
+    unsealed = False
     try:
+        if unseal:
+            sm.unseal(keys=unseal.split(","), root_token=token)
+            unsealed = True
+
+        client = sm.client
+        if client is None:
+            fatal("Can't connect or authenticate with Vault", exc_info=False, exitcode=1)
+
+        if client.seal_status["sealed"]:
+            fatal("Vault is currently sealed", exc_info=False, exitcode=4)
+
         path = sm.join(namespace, environ)
         _load_existing_secrets(sm, path)
         for filename in files:
@@ -111,7 +113,7 @@ def handler(
                 logging.error(f"{filename}: {e.__class__.__name__}", exc_info=True)
     finally:
         # reseal the vault
-        if unseal:
+        if unsealed:
             sm.seal()
 
 

--- a/envex/scripts/env2hvac.py
+++ b/envex/scripts/env2hvac.py
@@ -60,7 +60,7 @@ def handler(
     url: str | None = None,
     token: str | None = None,
     cert: tuple[str, str] | None = None,
-    verify: bool | str = True,
+    verify: bool | str | None = None,
     unseal: str | None = None,
     namespace: str | None = None,
     environ: str | None = None,
@@ -173,19 +173,20 @@ def main():
         default=None,
         help="Client cert key (if any)",
     )
-    parser.add_argument(
+    verify_group = parser.add_mutually_exclusive_group(required=False)
+    verify_group.add_argument(
         "-N",
         "--noverify",
         dest="verify",
         action="store_false",
-        default=True,
+        default=None,
         help="Disable server certificate verification",
     )
-    parser.add_argument(
+    verify_group.add_argument(
         "-C",
         "--cacert",
         dest="verify",
-        default=True,
+        default=None,
         help="Path to a custom CA certificate (do not use with -N)",
     )
     parser.add_argument(

--- a/envex/scripts/seal.py
+++ b/envex/scripts/seal.py
@@ -9,6 +9,8 @@ import os
 import textwrap
 from typing import TYPE_CHECKING
 
+from envex.env_hvac import _vault_verify_from_env
+
 if TYPE_CHECKING:
     import hvac
 
@@ -17,6 +19,7 @@ Seal or [-u] unseal a vault
 Uses environment variables:
   VAULT_ADDR - vault server url
   VAULT_CACERT - optional path to CA public certificate
+  VAULT_CAPATH - optional CA bundle file or certificate directory
   VAULT_TOKEN  - vault token with sufficient privilege
   VAULT_UNSEAL_KEYS <value,value,vault> - keys to unseal (if unsealing)
 """
@@ -75,7 +78,7 @@ def main():
     parser.add_argument(
         "-C",
         "--cacert",
-        default=os.getenv("VAULT_CACERT"),
+        default=None,
         help="Override path to CA cert key",
     )
     parser.add_argument(
@@ -94,7 +97,12 @@ def main():
 
     args = parser.parse_args()
 
-    verify = expand(args.cacert) if args.cacert else True
+    try:
+        verify = expand(args.cacert) if args.cacert else _vault_verify_from_env()
+    except ValueError as e:
+        logging.error(str(e))
+        raise SystemExit(1) from None
+
     try:
         client = _create_client(url=args.address, token=args.token, verify=verify)
     except HvacUnavailableError as e:

--- a/envex/scripts/seal.py
+++ b/envex/scripts/seal.py
@@ -7,8 +7,10 @@ Seal or [-u] unseal a vault
 import logging
 import os
 import textwrap
+from typing import TYPE_CHECKING
 
-import hvac
+if TYPE_CHECKING:
+    import hvac
 
 description = """\
 Seal or [-u] unseal a vault
@@ -18,6 +20,10 @@ Uses environment variables:
   VAULT_TOKEN  - vault token with sufficient privilege
   VAULT_UNSEAL_KEYS <value,value,vault> - keys to unseal (if unsealing)
 """
+
+
+class HvacUnavailableError(RuntimeError):
+    pass
 
 
 def expand(path: str):
@@ -31,6 +37,17 @@ def trim_indent(text):
         trimmed_lines = [line[leading_spaces:] for line in lines]
         return "\n".join(trimmed_lines)
     return text
+
+
+def _create_client(**kwargs) -> "hvac.Client":
+    try:
+        import hvac
+    except ImportError as exc:
+        raise HvacUnavailableError(
+            "hvac is required to operate the seal command; install envex with "
+            "Vault support or install hvac"
+        ) from exc
+    return hvac.Client(**kwargs)
 
 
 def main():
@@ -78,7 +95,11 @@ def main():
     args = parser.parse_args()
 
     verify = expand(args.cacert) if args.cacert else True
-    client = hvac.Client(url=args.address, token=args.token, verify=verify)
+    try:
+        client = _create_client(url=args.address, token=args.token, verify=verify)
+    except HvacUnavailableError as e:
+        logging.error(str(e))
+        raise SystemExit(1) from None
 
     try:
         if args.seal:

--- a/tests/test_cli_policy.py
+++ b/tests/test_cli_policy.py
@@ -39,7 +39,7 @@ def test_seal_exits_nonzero_on_operational_error(monkeypatch, caplog):
         def seal_status(self):
             raise RuntimeError("status failed")
 
-    monkeypatch.setattr(seal.hvac, "Client", lambda **_kwargs: FakeClient())
+    monkeypatch.setattr(seal, "_create_client", lambda **_kwargs: FakeClient())
     monkeypatch.setattr(
         sys, "argv", ["seal", "--address", "http://vault.local", "--token", "token"]
     )

--- a/tests/test_env2hvac_script.py
+++ b/tests/test_env2hvac_script.py
@@ -194,7 +194,7 @@ def test_handler_logs_success_after_write(tmp_path, monkeypatch, caplog):
     assert "Added or updated" not in caplog.text
 
 
-def test_handler_submits_unseal_keys_before_authentication_check(
+def test_handler_submits_unseal_keys_before_authentication_check_and_reseals(
     tmp_path, monkeypatch, caplog
 ):
     env_file = tmp_path / ".env"
@@ -206,6 +206,7 @@ def test_handler_submits_unseal_keys_before_authentication_check(
         def __init__(self, **kwargs):
             self.kwargs = kwargs
             self.unseal_calls = []
+            self.seal_calls = 0
             instances.append(self)
 
         @staticmethod
@@ -221,6 +222,10 @@ def test_handler_submits_unseal_keys_before_authentication_check(
             events.append("unseal")
             self.unseal_calls.append((keys, root_token))
 
+        def seal(self):
+            events.append("seal")
+            self.seal_calls += 1
+
     monkeypatch.setattr(env2hvac, "SecretsManager", FakeSecretsManager)
     caplog.set_level(logging.CRITICAL)
 
@@ -235,7 +240,8 @@ def test_handler_submits_unseal_keys_before_authentication_check(
 
     assert exc_info.value.code == 1
     assert instances[0].unseal_calls == [(["key-1", "key-2"], "root-token")]
-    assert events == ["unseal", "client"]
+    assert instances[0].seal_calls == 1
+    assert events == ["unseal", "client", "seal"]
     assert "Can't connect or authenticate with Vault" in caplog.text
 
 

--- a/tests/test_env2hvac_script.py
+++ b/tests/test_env2hvac_script.py
@@ -23,6 +23,32 @@ def test_main_supports_console_script_help(monkeypatch, capsys):
     assert "usage:" in capsys.readouterr().out
 
 
+@pytest.mark.parametrize(
+    "verify_args",
+    [
+        ["--noverify", "--cacert", "/tmp/ca.pem"],
+        ["--cacert", "/tmp/ca.pem", "--noverify"],
+    ],
+)
+def test_main_rejects_conflicting_verify_options(
+    monkeypatch, tmp_path, capsys, verify_args
+):
+    env_file = tmp_path / ".env"
+    env_file.write_text("PUBLIC=hello\n")
+
+    def fail_handler(*_args, **_kwargs):
+        raise AssertionError("handler should not be called")
+
+    monkeypatch.setattr(env2hvac, "handler", fail_handler)
+    monkeypatch.setattr(sys, "argv", ["env2hvac", *verify_args, str(env_file)])
+
+    with pytest.raises(SystemExit) as exc_info:
+        env2hvac.main()
+
+    assert exc_info.value.code == 2
+    assert "not allowed with argument" in capsys.readouterr().err
+
+
 def install_fake_secrets_manager(
     monkeypatch, fail_write=False, forbid_read=False, existing_values=None
 ):
@@ -93,6 +119,17 @@ def test_handler_writes_env_values_to_secret_manager(tmp_path, monkeypatch):
     assert instances[0].get_calls == ["myapp/prod"]
 
 
+def test_handler_passes_omitted_verify_as_vault_default(tmp_path, monkeypatch):
+    env_file = tmp_path / ".env"
+    env_file.write_text("PUBLIC=hello\n")
+
+    instances = install_fake_secrets_manager(monkeypatch)
+
+    env2hvac.handler([str(env_file)], namespace="myapp", environ="prod")
+
+    assert instances[0].kwargs["verify"] is None
+
+
 def test_handler_writes_when_existing_secret_read_is_forbidden(
     tmp_path, monkeypatch, caplog
 ):
@@ -155,6 +192,51 @@ def test_handler_logs_success_after_write(tmp_path, monkeypatch, caplog):
         env2hvac.handler([str(env_file)], namespace="myapp", environ="prod")
 
     assert "Added or updated" not in caplog.text
+
+
+def test_handler_submits_unseal_keys_before_authentication_check(
+    tmp_path, monkeypatch, caplog
+):
+    env_file = tmp_path / ".env"
+    env_file.write_text("PUBLIC=hello\n")
+    events = []
+    instances = []
+
+    class FakeSecretsManager:
+        def __init__(self, **kwargs):
+            self.kwargs = kwargs
+            self.unseal_calls = []
+            instances.append(self)
+
+        @staticmethod
+        def join(*args, sep="/"):
+            return sep.join([a.strip(sep) for a in args if a])
+
+        @property
+        def client(self):
+            events.append("client")
+            return None
+
+        def unseal(self, keys, root_token):
+            events.append("unseal")
+            self.unseal_calls.append((keys, root_token))
+
+    monkeypatch.setattr(env2hvac, "SecretsManager", FakeSecretsManager)
+    caplog.set_level(logging.CRITICAL)
+
+    with pytest.raises(SystemExit) as exc_info:
+        env2hvac.handler(
+            [str(env_file)],
+            token="root-token",
+            unseal="key-1,key-2",
+            namespace="myapp",
+            environ="prod",
+        )
+
+    assert exc_info.value.code == 1
+    assert instances[0].unseal_calls == [(["key-1", "key-2"], "root-token")]
+    assert events == ["unseal", "client"]
+    assert "Can't connect or authenticate with Vault" in caplog.text
 
 
 def test_handler_fails_when_explicit_input_file_is_missing(tmp_path, monkeypatch, caplog):

--- a/tests/test_env_hvac.py
+++ b/tests/test_env_hvac.py
@@ -142,6 +142,65 @@ def test_secrets_manager_initialization_uses_logical_paths(
     assert manager.path("app/prod") == SecretsManager.join(expected_base, "app/prod")
 
 
+def test_vault_capath_is_used_when_cacert_is_absent(tmp_path, monkeypatch):
+    ca_dir = tmp_path / "ca-dir"
+    ca_dir.mkdir()
+    monkeypatch.delenv("VAULT_CACERT", raising=False)
+    monkeypatch.setenv("VAULT_CAPATH", ca_dir.as_posix())
+    instances = install_fake_hvac_client(monkeypatch)
+
+    SecretsManager()
+
+    assert instances[0].kwargs["verify"] == ca_dir.as_posix()
+
+
+def test_vault_cacert_takes_precedence_over_vault_capath(tmp_path, monkeypatch):
+    ca_cert = tmp_path / "ca.pem"
+    ca_cert.write_text("certificate bundle")
+    ca_dir = tmp_path / "ca-dir"
+    ca_dir.mkdir()
+    monkeypatch.setenv("VAULT_CACERT", ca_cert.as_posix())
+    monkeypatch.setenv("VAULT_CAPATH", ca_dir.as_posix())
+    instances = install_fake_hvac_client(monkeypatch)
+
+    SecretsManager()
+
+    assert instances[0].kwargs["verify"] == ca_cert.as_posix()
+
+
+def test_vault_capath_file_is_used_as_ca_bundle(tmp_path, monkeypatch):
+    ca_file = tmp_path / "ca-file.pem"
+    ca_file.write_text("not a directory")
+    monkeypatch.delenv("VAULT_CACERT", raising=False)
+    monkeypatch.setenv("VAULT_CAPATH", ca_file.as_posix())
+    instances = install_fake_hvac_client(monkeypatch)
+
+    SecretsManager()
+
+    assert instances[0].kwargs["verify"] == ca_file.as_posix()
+
+
+def test_invalid_vault_capath_raises_value_error(tmp_path, monkeypatch):
+    missing_path = tmp_path / "missing-ca-path"
+    monkeypatch.delenv("VAULT_CACERT", raising=False)
+    monkeypatch.setenv("VAULT_CAPATH", missing_path.as_posix())
+    install_fake_hvac_client(monkeypatch)
+
+    with pytest.raises(ValueError, match=f"VAULT_CAPATH={missing_path.as_posix()!r}"):
+        SecretsManager()
+
+
+@pytest.mark.parametrize("verify", [True, False, "/explicit/ca.pem"])
+def test_explicit_verify_overrides_vault_capath(verify, tmp_path, monkeypatch):
+    monkeypatch.setenv("VAULT_CACERT", (tmp_path / "env-ca.pem").as_posix())
+    monkeypatch.setenv("VAULT_CAPATH", (tmp_path / "env-ca-dir").as_posix())
+    instances = install_fake_hvac_client(monkeypatch)
+
+    SecretsManager(verify=verify)
+
+    assert instances[0].kwargs["verify"] == verify
+
+
 def test_initialization_failure_is_instance_local(monkeypatch):
     calls = 0
 
@@ -341,3 +400,22 @@ def test_seal_unseal():
     assert manager.sealed
     manager.unseal([], None)
     assert not manager.sealed
+
+
+def test_sealed_reads_raw_client_when_authentication_fails():
+    manager = make_manager()
+    manager._client.authenticated = False
+    manager._client.seal_status["sealed"] = True
+
+    assert manager.client is None
+    assert manager.sealed is True
+
+
+def test_unseal_uses_raw_client_when_authentication_fails():
+    manager = make_manager()
+    manager._client.authenticated = False
+    manager._client.seal_status["sealed"] = True
+
+    assert manager.client is None
+    assert manager.unseal(["key-1", "key-2"], "root-token") is True
+    assert manager.sealed is False

--- a/tests/test_env_hvac.py
+++ b/tests/test_env_hvac.py
@@ -411,6 +411,16 @@ def test_sealed_reads_raw_client_when_authentication_fails():
     assert manager.sealed is True
 
 
+def test_seal_uses_raw_client_when_authentication_fails():
+    manager = make_manager()
+    manager._client.authenticated = False
+    manager._client.seal_status["sealed"] = False
+
+    assert manager.client is None
+    assert manager.seal() is True
+    assert manager.sealed is True
+
+
 def test_unseal_uses_raw_client_when_authentication_fails():
     manager = make_manager()
     manager._client.authenticated = False

--- a/tests/test_seal_script.py
+++ b/tests/test_seal_script.py
@@ -1,3 +1,4 @@
+import builtins
 import sys
 
 import pytest
@@ -38,7 +39,7 @@ def test_seal_status_uses_boolean_value_and_default_verify(
             }
 
     monkeypatch.delenv("VAULT_CACERT", raising=False)
-    monkeypatch.setattr(seal.hvac, "Client", FakeClient)
+    monkeypatch.setattr(seal, "_create_client", lambda **kwargs: FakeClient(**kwargs))
     monkeypatch.setattr(
         sys, "argv", ["seal", "--address", "http://vault.local", "--token", "token"]
     )
@@ -65,7 +66,7 @@ def test_seal_expands_cacert_path(monkeypatch, capsys):
             }
 
     monkeypatch.setenv("HOME", "/tmp/envex-home")
-    monkeypatch.setattr(seal.hvac, "Client", FakeClient)
+    monkeypatch.setattr(seal, "_create_client", lambda **kwargs: FakeClient(**kwargs))
     monkeypatch.setattr(
         sys,
         "argv",
@@ -84,3 +85,43 @@ def test_seal_expands_cacert_path(monkeypatch, capsys):
 
     assert calls[-1]["verify"] == "/tmp/envex-home/ca.pem"
     assert "Vault Status: Unsealed" in capsys.readouterr().out
+
+
+def test_seal_help_does_not_require_hvac(monkeypatch, capsys):
+    real_import = builtins.__import__
+
+    def import_without_hvac(name, *args, **kwargs):
+        if name == "hvac":
+            raise ModuleNotFoundError("No module named 'hvac'")
+        return real_import(name, *args, **kwargs)
+
+    monkeypatch.setattr(builtins, "__import__", import_without_hvac)
+    monkeypatch.setattr(sys, "argv", ["seal", "--help"])
+
+    with pytest.raises(SystemExit) as exc_info:
+        seal.main()
+
+    assert exc_info.value.code == 0
+    assert "usage:" in capsys.readouterr().out
+
+
+def test_seal_operation_without_hvac_exits_nonzero(monkeypatch, caplog):
+    real_import = builtins.__import__
+
+    def import_without_hvac(name, *args, **kwargs):
+        if name == "hvac":
+            raise ModuleNotFoundError("No module named 'hvac'")
+        return real_import(name, *args, **kwargs)
+
+    monkeypatch.setattr(builtins, "__import__", import_without_hvac)
+    monkeypatch.setattr(
+        sys, "argv", ["seal", "--address", "http://vault.local", "--token", "token"]
+    )
+    caplog.set_level("ERROR")
+
+    with pytest.raises(SystemExit) as exc_info:
+        seal.main()
+
+    assert exc_info.value.code == 1
+    assert "hvac is required to operate the seal command" in caplog.text
+    assert "RuntimeError:" not in caplog.text

--- a/tests/test_seal_script.py
+++ b/tests/test_seal_script.py
@@ -39,6 +39,7 @@ def test_seal_status_uses_boolean_value_and_default_verify(
             }
 
     monkeypatch.delenv("VAULT_CACERT", raising=False)
+    monkeypatch.delenv("VAULT_CAPATH", raising=False)
     monkeypatch.setattr(seal, "_create_client", lambda **kwargs: FakeClient(**kwargs))
     monkeypatch.setattr(
         sys, "argv", ["seal", "--address", "http://vault.local", "--token", "token"]
@@ -85,6 +86,50 @@ def test_seal_expands_cacert_path(monkeypatch, capsys):
 
     assert calls[-1]["verify"] == "/tmp/envex-home/ca.pem"
     assert "Vault Status: Unsealed" in capsys.readouterr().out
+
+
+def test_seal_uses_vault_capath_default(monkeypatch, tmp_path, capsys):
+    calls = []
+    ca_dir = tmp_path / "ca-dir"
+    ca_dir.mkdir()
+
+    class FakeClient:
+        def __init__(self, **kwargs):
+            calls.append(kwargs)
+            self.seal_status = {
+                "sealed": False,
+                "type": "shamir",
+                "t": 3,
+                "n": 5,
+            }
+
+    monkeypatch.delenv("VAULT_CACERT", raising=False)
+    monkeypatch.setenv("VAULT_CAPATH", ca_dir.as_posix())
+    monkeypatch.setattr(seal, "_create_client", lambda **kwargs: FakeClient(**kwargs))
+    monkeypatch.setattr(
+        sys, "argv", ["seal", "--address", "http://vault.local", "--token", "token"]
+    )
+
+    seal.main()
+
+    assert calls[-1]["verify"] == ca_dir.as_posix()
+    assert "Vault Status: Unsealed" in capsys.readouterr().out
+
+
+def test_seal_invalid_vault_capath_exits_nonzero(monkeypatch, tmp_path, caplog):
+    missing_path = tmp_path / "missing-ca-path"
+    monkeypatch.delenv("VAULT_CACERT", raising=False)
+    monkeypatch.setenv("VAULT_CAPATH", missing_path.as_posix())
+    monkeypatch.setattr(
+        sys, "argv", ["seal", "--address", "http://vault.local", "--token", "token"]
+    )
+    caplog.set_level("ERROR")
+
+    with pytest.raises(SystemExit) as exc_info:
+        seal.main()
+
+    assert exc_info.value.code == 1
+    assert f"VAULT_CAPATH={missing_path.as_posix()!r}" in caplog.text
 
 
 def test_seal_help_does_not_require_hvac(monkeypatch, capsys):

--- a/tests/test_wrapper.py
+++ b/tests/test_wrapper.py
@@ -298,9 +298,9 @@ def test_env_bool_rejects_invalid_strings(value):
 @pytest.mark.parametrize(
     ("skip_verify", "expected_verify"),
     [
-        (None, True),
-        ("false", True),
-        ("0", True),
+        (None, None),
+        ("false", None),
+        ("0", None),
         ("true", False),
         ("1", False),
     ],
@@ -709,10 +709,11 @@ def test_plaintext_fallback_with_env_password_is_not_corrupted(
 
 @pytest.mark.parametrize("key", ["SECG_KEY", "SECF_KEY"])
 @pytest.mark.parametrize("source", ["env-file", "stream"])
+@pytest.mark.parametrize("prefix", ["", "# comment\n\n"])
 def test_plaintext_magic_prefix_key_with_env_password_is_not_rejected(
-    password, tmp_path, key, source
+    password, tmp_path, key, source, prefix
 ):
-    data = f"{key}=value\n"
+    data = f"{prefix}{key}=value\n"
     if source == "env-file":
         env_file = tmp_path / ".env"
         env_file.write_text(data)
@@ -729,8 +730,17 @@ def test_plaintext_magic_prefix_key_with_env_password_is_not_rejected(
     assert env[key] == "value"
 
 
-def test_encrypted_stream_wrong_password_raises_decrypt_error(password):
+def test_encrypted_stream_wrong_password_raises_decrypt_error(password, monkeypatch):
+    def token_bytes(size):
+        if size == env_crypto.SALT_LENGTH:
+            return b"=\n" + b"s" * (size - 2)
+        if size == env_crypto.GCM_NONCE_LENGTH:
+            return b"n" * size
+        return b"x" * size
+
+    monkeypatch.setattr(env_crypto.secrets, "token_bytes", token_bytes)
     stream = encrypt_data(io.BytesIO(b"ONE=1\n"), password)
+    assert stream.getvalue().startswith(b"SECG=\n")
 
     with pytest.raises(DecryptError):
         envex.Env(stream, decrypt=True, password="wrong-password")


### PR DESCRIPTION
Summary:
- Harden Vault TLS verification defaults, including `VAULT_CACERT` / `VAULT_CAPATH` handling.
- Allow seal status and unseal flows to run before authentication succeeds.
- Defer the optional `hvac` import in `seal` so help remains usable without Vault dependencies.
- Tighten dotenv encrypted/plaintext detection around envex magic prefixes and update the changelog.

Linear: [UT-203](https://linear.app/uniquode/issue/UT-203/harden-vault-setup-and-seal-handling)