### PR TITLE
UT-344: Share Vault manager contexts safely

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # ChangeLog
 
+### v5.1.0
+
+- ⚠️ BREAKING CHANGE: Vault is now used only when a complete effective configuration resolves. Partial configuration emits a warning and is skipped; once configured, Vault authentication, network, TLS, permission, and sealed-state failures raise instead of silently falling back to local values.
+- `Env(secrets_manager=...)` now creates a path-scoped view that reuses an authenticated Vault client while retaining independent path selection.
+- Vault secret caches are now isolated by mount point and logical path, preventing cached values from one document being written to another.
+- `env2hvac` no longer creates an additional Vault-capable `Env` while parsing each local dotenv input.
+
 ### v5.0.0
 
 - ⚠️ BREAKING CHANGE: encrypted files now use authenticated AES-256-GCM. Files encrypted by envex 5.0.0 or later cannot be decrypted by envex 4.x or older. The new format validates encrypted data with a GCM authentication tag.

--- a/README.md
+++ b/README.md
@@ -32,9 +32,9 @@ The provided `envcrypt` utility conveniently allows conversion between encrypted
 
 #### Vault support
 Alternatively, `envex` provides seamless integration with HashiCorp Vault. This reduces the need to store plaintext secrets on the filesystem and provides a more secure approach for managing secrets.
-HashiCorp Vault functionality is optional, and is activated automatically when the `hvac` module is installed into the active virtual environment, and where connection and authentication to Vault succeed.
-Values fetched from Vault are cached in the `SecretsManager` instance during its lifetime to reduce repeated API reads.
-Envex does not automatically expire this cache or invalidate it when values are changed outside the instance; create a new `SecretsManager` or call `get_secrets()` to refresh values from Vault.
+HashiCorp Vault functionality is optional. With no usable Vault configuration, envex uses local values only. Partial configuration is logged and skipped; once a complete Vault configuration resolves, Vault failures are raised rather than silently falling back to local values.
+Values fetched from Vault are cached by mounted logical path in the `SecretsManager` connection context. Derived managers created from the same manager reuse entries for the same path only.
+Envex does not automatically expire this cache or invalidate it when values are changed outside the instance; call `get_secrets()` to refresh values from Vault.
 
 #### Extended variables
 `envex` provides many features not available in other dotenv handlers (python-dotenv, etc.) including recursive
@@ -115,6 +115,7 @@ In addition, Env supports a few HashiCorp Vault configuration parameters as well
 * base_path: (optional) logical secrets base path, or "environment" for secrets (default is None).
   This is used to prefix the logical path to the secret, i.e. `f"{base_path}/key"`.
 * mount_point: (optional) Vault secrets engine mount point (default is `secret/`; values may be provided with or without slashes and are normalized internally).
+* secrets_manager: (optional) an authenticated `SecretsManager` to reuse. Envex creates a path-scoped view that shares the existing Vault client but keeps its own base path and cache entry selection. It cannot be combined with connection options such as `url`, `token`, or `verify`.
 
 Environment values override Vault values by default. Set `ENVEX_SOURCE=vault` to let Vault values override local environment values.
 

--- a/envex/env_hvac.py
+++ b/envex/env_hvac.py
@@ -169,9 +169,9 @@ class SecretsManager:
     ) -> "SecretsManager":
         """Create a path-scoped view that borrows an authenticated manager client."""
         if not isinstance(manager, cls):
-            raise TypeError("secrets_manager must be a SecretsManager instance")
+            raise TypeError("manager must be a SecretsManager instance")
         if manager.client is None:
-            raise ValueError("secrets_manager must have an authenticated Vault client")
+            raise ValueError("manager must have an authenticated Vault client")
 
         view = cls.__new__(cls)
         view._client = manager._client
@@ -236,7 +236,8 @@ class SecretsManager:
 
     @property
     def secrets(self) -> dict:
-        return self._secrets
+        """Return a snapshot of the default-path secrets."""
+        return dict(self._secrets)
 
     def get_secrets(self, path: str = "") -> dict:
         kv2 = self.kv2
@@ -250,14 +251,16 @@ class SecretsManager:
             except Exception as exc:
                 if not _is_invalid_path(exc):
                     raise
-                return self._replace_cached(path, {})
+                return dict(self._replace_cached(path, {}))
             if response is not None and "data" in response:
-                return self._replace_cached(path, response["data"].get("data", {}))
-        return self._cached(path)
+                return dict(self._replace_cached(path, response["data"].get("data", {})))
+        return dict(self._cached(path))
 
     def set_secrets(self, path: str = "", values: dict | None = None):
         kv2 = self.kv2
         if kv2 and values:
+            if self._cache_key(path) not in self._cache:
+                self.get_secrets(path)
             secrets = self._cached(path)
             secrets.update(values)
             if secrets:
@@ -278,10 +281,12 @@ class SecretsManager:
     def get_secret(self, key: str, default: str | None = None, error: bool = False):
         if self.client:
             # Check if the secret is already in the cache
-            if not self.secrets:
+            secrets = self._cached()
+            if not secrets:
                 self.get_secrets()
-            if key in self.secrets:
-                return self.secrets[key]
+                secrets = self._cached()
+            if key in secrets:
+                return secrets[key]
         if error and default is None:
             raise KeyError(key)
         # Placeholder or None value when hvac is not available or secret not found
@@ -290,12 +295,14 @@ class SecretsManager:
     def set_secret(self, key: str, value: str):
         kv2 = self.kv2
         if kv2 and not any((key is None, value is None)):
-            if not self.secrets:
+            secrets = self._cached()
+            if not secrets:
                 self.get_secrets()
-            self.secrets[key] = value
+                secrets = self._cached()
+            secrets[key] = value
             kv2.create_or_update_secret(
                 path=self.path(""),
-                secret=dict(self.secrets),
+                secret=dict(secrets),
                 mount_point=self.mount_point,
             )
 
@@ -304,7 +311,8 @@ class SecretsManager:
         if kv2:
             secrets = self._cached(path)
             if not secrets:
-                secrets = self.get_secrets(path)
+                self.get_secrets(path)
+                secrets = self._cached(path)
             if key in secrets:
                 del secrets[key]
                 if secrets:
@@ -323,7 +331,8 @@ class SecretsManager:
         if self.client:
             secrets = self._cached(path)
             if not secrets:
-                secrets = self.get_secrets(path)
+                self.get_secrets(path)
+                secrets = self._cached(path)
             yield from secrets.keys()
 
     def seal(self):

--- a/envex/env_hvac.py
+++ b/envex/env_hvac.py
@@ -157,7 +157,30 @@ class SecretsManager:
             self._client = None
         self._mount_point = mount_point.strip("/")
         self._base_path = self.join(base_path)
-        self._secrets = {}
+        self._cache: dict[tuple[str, str], dict] = {}
+
+    @classmethod
+    def from_manager(
+        cls,
+        manager: "SecretsManager",
+        *,
+        base_path: str | None = None,
+        mount_point: str | None = None,
+    ) -> "SecretsManager":
+        """Create a path-scoped view that borrows an authenticated manager client."""
+        if not isinstance(manager, cls):
+            raise TypeError("secrets_manager must be a SecretsManager instance")
+        if manager.client is None:
+            raise ValueError("secrets_manager must have an authenticated Vault client")
+
+        view = cls.__new__(cls)
+        view._client = manager._client
+        view.hvac_disabled = manager.hvac_disabled
+        view._engine = manager._engine
+        view._mount_point = (mount_point or manager.mount_point).strip("/")
+        view._base_path = cls.join(manager.base_path if base_path is None else base_path)
+        view._cache = manager._cache
+        return view
 
     @staticmethod
     def join(*args, sep="/"):
@@ -174,6 +197,31 @@ class SecretsManager:
     def path(self, key) -> str:
         return self.join(self.base_path, key)
 
+    def _cache_key(self, path: str = "") -> tuple[str, str]:
+        return self.mount_point, self.path(path)
+
+    def _cached(self, path: str = "") -> dict:
+        return self._cache.setdefault(self._cache_key(path), {})
+
+    def _replace_cached(self, path: str, values: dict) -> dict:
+        cached = dict(values)
+        self._cache[self._cache_key(path)] = cached
+        return cached
+
+    def _clear_cached(self, path: str = "") -> None:
+        self._cache.pop(self._cache_key(path), None)
+
+    @property
+    def _secrets(self) -> dict:
+        """Compatibility alias for the manager's default-path cache entry."""
+        return self._cached()
+
+    @_secrets.setter
+    def _secrets(self, values: dict) -> None:
+        if not hasattr(self, "_cache"):
+            self._cache = {}
+        self._replace_cached("", values)
+
     @property
     def kv2(self):
         client = self.client
@@ -182,14 +230,9 @@ class SecretsManager:
     @property
     def client(self):
         # returns hvac.Client | None
-        try:
-            client = self._client
-            if client is not None and client.is_authenticated():
-                return client
-        except Exception as exc:
-            logging.debug(
-                f"{exc.__class__.__name__} Vault client cannot authenticate {exc}"
-            )
+        client = self._client
+        if client is not None and client.is_authenticated():
+            return client
 
     @property
     def secrets(self) -> dict:
@@ -207,20 +250,20 @@ class SecretsManager:
             except Exception as exc:
                 if not _is_invalid_path(exc):
                     raise
-                self._secrets = {}
-                return self.secrets
+                return self._replace_cached(path, {})
             if response is not None and "data" in response:
-                self._secrets = response["data"].get("data", {})
-        return self.secrets
+                return self._replace_cached(path, response["data"].get("data", {}))
+        return self._cached(path)
 
     def set_secrets(self, path: str = "", values: dict | None = None):
         kv2 = self.kv2
         if kv2 and values:
-            self._secrets |= values
-            if self.secrets:
+            secrets = self._cached(path)
+            secrets.update(values)
+            if secrets:
                 kv2.create_or_update_secret(
                     path=self.path(path),
-                    secret=self.secrets,
+                    secret=dict(secrets),
                     mount_point=self.mount_point,
                 )
 
@@ -230,7 +273,7 @@ class SecretsManager:
             kv2.delete_metadata_and_all_versions(
                 path=self.path(path), mount_point=self.mount_point
             )
-        self._secrets.clear()
+        self._clear_cached(path)
 
     def get_secret(self, key: str, default: str | None = None, error: bool = False):
         if self.client:
@@ -259,27 +302,29 @@ class SecretsManager:
     def delete_secret(self, key: str, path: str = "") -> None:
         kv2 = self.kv2
         if kv2:
-            if not self.secrets:
-                self.get_secrets()
-            if self.secrets and key in self.secrets:
-                del self.secrets[key]
-                if self.secrets:
+            secrets = self._cached(path)
+            if not secrets:
+                secrets = self.get_secrets(path)
+            if key in secrets:
+                del secrets[key]
+                if secrets:
                     kv2.create_or_update_secret(
                         path=self.path(path),
-                        secret=dict(self.secrets),
+                        secret=dict(secrets),
                         mount_point=self.mount_point,
                     )
                 else:
                     kv2.delete_metadata_and_all_versions(
                         path=self.path(path), mount_point=self.mount_point
                     )
-                    self.secrets.clear()
+                    self._clear_cached(path)
 
     def list_secrets(self, path: str = "") -> Iterator[str]:
         if self.client:
-            if not self.secrets:
-                self.get_secrets()
-            yield from self.secrets.keys()
+            secrets = self._cached(path)
+            if not secrets:
+                secrets = self.get_secrets(path)
+            yield from secrets.keys()
 
     def seal(self):
         # Seal/status/unseal operations must work before authentication succeeds:

--- a/envex/env_wrapper.py
+++ b/envex/env_wrapper.py
@@ -5,6 +5,7 @@ Type smart wrapper around os.environ
 
 import contextlib
 import inspect
+import logging
 import os
 import re
 from pathlib import Path
@@ -30,6 +31,20 @@ class Env:
     _LOAD_ENV_KWARGS = frozenset(inspect.signature(load_env).parameters)
     _SOURCE_KEY = "ENVEX_SOURCE"
     _SOURCE_VALUES = frozenset(("env", "vault"))
+    _VAULT_ENV_VARS = frozenset(
+        (
+            "VAULT_ADDR",
+            "VAULT_TOKEN",
+            "VAULT_PATH",
+            "VAULT_CACERT",
+            "VAULT_CAPATH",
+            "VAULT_CLIENT_CERT",
+            "VAULT_CLIENT_KEY",
+            "VAULT_SKIP_VERIFY",
+            "VAULT_TIMEOUT",
+            "VAULT_NAMESPACE",
+        )
+    )
 
     def __init__(
         self,
@@ -44,6 +59,7 @@ class Env:
         base_path: str | None = None,
         engine: str | None = None,
         mount_point: str | None = None,
+        secrets_manager: SecretsManager | None = None,
         **kwargs,
     ):
         """
@@ -72,6 +88,7 @@ class Env:
         @param base_path: (optional) str base path for secrets (default=None)
         @param engine: (optional) str vault secrets engine (default=None)
         @param mount_point: (optional) str vault secrets mount point (default=None, determined by engine)
+        @param secrets_manager: (optional) existing authenticated manager to reuse
         Environment values override Vault by default. Set ENVEX_SOURCE=vault
             to let Vault values override local values.
         @param working_dirs: (optional) bool whether to include PWD/CWD (default=True)
@@ -120,16 +137,88 @@ class Env:
             )
         else:
             vault_verify = verify
-        self.secret_manager = SecretsManager(
+        self.secret_manager = self._create_secret_manager(
+            secrets_manager=secrets_manager,
             url=url,
             token=token,
             cert=cert,
             verify=vault_verify,
+            connection_verify=verify,
             base_path=base_path,
             engine=engine,
             mount_point=mount_point,
             timeout=timeout,
         )
+
+    def _create_secret_manager(
+        self,
+        *,
+        secrets_manager: SecretsManager | None,
+        url: str | None,
+        token: str | None,
+        cert,
+        verify: bool | str | None,
+        connection_verify: bool | str | None,
+        base_path: str | None,
+        engine: str | None,
+        mount_point: str | None,
+        timeout: int | None,
+    ) -> SecretsManager | None:
+        if secrets_manager is not None:
+            self._reject_manager_connection_options(
+                url=url,
+                token=token,
+                cert=cert,
+                verify=connection_verify,
+                engine=engine,
+                timeout=timeout,
+            )
+            return SecretsManager.from_manager(
+                secrets_manager, base_path=base_path, mount_point=mount_point
+            )
+
+        if not self._vault_is_configured(url=url, token=token):
+            return None
+
+        manager = SecretsManager(
+            url=url,
+            token=token,
+            cert=cert,
+            verify=verify,
+            base_path=base_path,
+            engine=engine,
+            mount_point=mount_point,
+            timeout=timeout,
+        )
+        if manager.client is None:
+            raise RuntimeError("Vault is configured but cannot authenticate")
+        return manager
+
+    def _vault_is_configured(self, *, url: str | None, token: str | None) -> bool:
+        effective_token = token or self.env.get("VAULT_TOKEN")
+        if not effective_token:
+            try:
+                from hvac.utils import get_token_from_env
+            except ImportError:
+                effective_token = None
+            else:
+                effective_token = get_token_from_env()
+        signals = bool(url or token) or any(
+            self.env.get(name) is not None for name in self._VAULT_ENV_VARS
+        )
+        if effective_token:
+            return True
+        if signals:
+            logging.warning("Vault is skipped because configuration is incomplete")
+        return False
+
+    @staticmethod
+    def _reject_manager_connection_options(**options) -> None:
+        supplied = [name for name, value in options.items() if value is not None]
+        if supplied:
+            raise ValueError(
+                "secrets_manager cannot be combined with " + ", ".join(supplied)
+            )
 
     @staticmethod
     def _is_stream(value):
@@ -224,8 +313,9 @@ class Env:
         # getting from the environment is the least expensive
         value = self.env.get(var, None)
         # not set or isn't primary, check secrets manager
-        if (value is None or not self.env_source) and hasattr(self, "secret_manager"):
-            sm_value = self.secret_manager.get_secret(var, None)
+        manager = getattr(self, "secret_manager", None)
+        if (value is None or not self.env_source) and manager is not None:
+            sm_value = manager.get_secret(var, None)
             if sm_value is not None:
                 value = sm_value
         return default if value is None else value

--- a/envex/scripts/env2hvac.py
+++ b/envex/scripts/env2hvac.py
@@ -90,12 +90,6 @@ def handler(
                     env_file=filename,
                     update=False,
                     errors=False,
-                    # pass these on in case we need them for completion
-                    url=url,
-                    token=token,
-                    cert=cert,
-                    verify=verify,
-                    base_path=path,
                 )
                 count = 0
                 secrets = {}

--- a/tests/test_env_hvac.py
+++ b/tests/test_env_hvac.py
@@ -307,6 +307,20 @@ def test_get_secrets_uses_kv_v2_read_with_mount_and_logical_path():
     ]
 
 
+def test_secret_snapshots_do_not_expose_the_internal_cache():
+    kv2 = FakeKvV2({("secret", "base/app"): {"KEY": "original"}})
+    manager = make_manager(base_path="base", kv2=kv2)
+
+    fetched = manager.get_secrets("app")
+    fetched["KEY"] = "changed"
+
+    assert manager._cached("app") == {"KEY": "original"}
+    manager._secrets = {"DEFAULT": "original"}
+    snapshot = manager.secrets
+    snapshot["DEFAULT"] = "changed"
+    assert manager._secrets == {"DEFAULT": "original"}
+
+
 def test_get_secrets_treats_missing_kv_path_as_empty():
     class MissingKvV2(FakeKvV2):
         def read_secret_version(self, path, version=None, mount_point="secret", **kwargs):
@@ -321,18 +335,25 @@ def test_get_secrets_treats_missing_kv_path_as_empty():
 
 
 def test_set_secrets_uses_kv_v2_write_with_mount_and_logical_path():
-    kv2 = FakeKvV2()
+    kv2 = FakeKvV2({("custom", "base/app"): {"EXISTING": "keep"}})
     manager = make_manager(base_path="base", mount_point="custom", kv2=kv2)
-    manager._secrets = {"EXISTING": "keep"}
 
     manager.set_secrets("app", values={"PUBLIC": "hello"})
 
     assert kv2.write_calls == [
         {
             "path": "base/app",
-            "secret": {"PUBLIC": "hello"},
+            "secret": {"EXISTING": "keep", "PUBLIC": "hello"},
             "cas": None,
             "mount_point": "custom",
+        }
+    ]
+    assert kv2.read_calls == [
+        {
+            "path": "base/app",
+            "version": None,
+            "mount_point": "custom",
+            "kwargs": {"raise_on_deleted_version": True},
         }
     ]
 

--- a/tests/test_env_hvac.py
+++ b/tests/test_env_hvac.py
@@ -330,7 +330,7 @@ def test_set_secrets_uses_kv_v2_write_with_mount_and_logical_path():
     assert kv2.write_calls == [
         {
             "path": "base/app",
-            "secret": {"EXISTING": "keep", "PUBLIC": "hello"},
+            "secret": {"PUBLIC": "hello"},
             "cas": None,
             "mount_point": "custom",
         }
@@ -357,7 +357,31 @@ def test_delete_secrets_uses_kv_v2_metadata_delete():
     manager.delete_secrets("app")
 
     assert kv2.delete_calls == [{"path": "base/app", "mount_point": "secret"}]
-    assert manager.secrets == {}
+    assert manager.secrets == {"PUBLIC": "hello"}
+
+
+def test_cache_entries_are_isolated_by_path_and_shared_by_manager_views():
+    kv2 = FakeKvV2(
+        {
+            ("secret", "one"): {"VALUE": "one"},
+            ("secret", "two"): {"VALUE": "two"},
+        }
+    )
+    source = make_manager(base_path="one", kv2=kv2)
+    view = SecretsManager.from_manager(source, base_path="two")
+
+    assert source.get_secrets() == {"VALUE": "one"}
+    assert view.get_secrets() == {"VALUE": "two"}
+    assert source.secrets == {"VALUE": "one"}
+    assert view.secrets == {"VALUE": "two"}
+
+
+def test_manager_view_requires_authenticated_source():
+    source = make_manager()
+    source._client.authenticated = False
+
+    with pytest.raises(ValueError, match="authenticated"):
+        SecretsManager.from_manager(source)
 
 
 def test_get_set_list_and_delete_secret():

--- a/tests/test_wrapper.py
+++ b/tests/test_wrapper.py
@@ -313,8 +313,9 @@ def test_vault_skip_verify_uses_strict_boolean_parsing(
     class FakeSecretsManager:
         def __init__(self, **kwargs):
             calls.append(kwargs)
+            self.client = object()
 
-    environ = {}
+    environ = {"VAULT_TOKEN": "token"}
     if skip_verify is not None:
         environ["VAULT_SKIP_VERIFY"] = skip_verify
 
@@ -331,9 +332,13 @@ def test_explicit_vault_verify_overrides_skip_verify(verify, monkeypatch):
     class FakeSecretsManager:
         def __init__(self, **kwargs):
             calls.append(kwargs)
+            self.client = object()
 
     monkeypatch.setattr("envex.env_wrapper.SecretsManager", FakeSecretsManager)
-    envex.Env(environ={"VAULT_SKIP_VERIFY": "true"}, verify=verify)
+    envex.Env(
+        environ={"VAULT_SKIP_VERIFY": "true", "VAULT_TOKEN": "token"},
+        verify=verify,
+    )
 
     assert calls[-1]["verify"] == verify
 
@@ -347,6 +352,65 @@ def test_invalid_vault_skip_verify_raises_value_error(monkeypatch):
 
     with pytest.raises(ValueError):
         envex.Env(environ={"VAULT_SKIP_VERIFY": "treu"}, verify=None)
+
+
+def test_env_skips_vault_without_configuration(monkeypatch):
+    class FakeSecretsManager:
+        def __init__(self, **_kwargs):
+            raise AssertionError("Vault should not be initialized")
+
+    monkeypatch.setattr("envex.env_wrapper.SecretsManager", FakeSecretsManager)
+
+    env = envex.Env(environ={})
+
+    assert env.secret_manager is None
+
+
+def test_env_warns_and_skips_partial_vault_configuration(monkeypatch, caplog):
+    class FakeSecretsManager:
+        def __init__(self, **_kwargs):
+            raise AssertionError("Vault should not be initialized")
+
+    monkeypatch.setattr("envex.env_wrapper.SecretsManager", FakeSecretsManager)
+
+    env = envex.Env(environ={"VAULT_ADDR": "https://vault.example"})
+
+    assert env.secret_manager is None
+    assert "configuration is incomplete" in caplog.text
+
+
+def test_env_creates_path_scoped_view_from_secrets_manager(monkeypatch):
+    class FakeSecretsManager:
+        def __init__(self, **_kwargs):
+            self.client = object()
+
+        @classmethod
+        def from_manager(cls, manager, *, base_path=None, mount_point=None):
+            return (manager, base_path, mount_point)
+
+    monkeypatch.setattr("envex.env_wrapper.SecretsManager", FakeSecretsManager)
+    source = FakeSecretsManager()
+
+    env = envex.Env(
+        environ={}, secrets_manager=source, base_path="other", mount_point="custom"
+    )
+
+    assert env.secret_manager == (source, "other", "custom")
+
+
+def test_env_rejects_connection_options_with_secrets_manager(monkeypatch):
+    class FakeSecretsManager:
+        def __init__(self, **_kwargs):
+            self.client = object()
+
+        @classmethod
+        def from_manager(cls, *_args, **_kwargs):
+            raise AssertionError("manager view should not be created")
+
+    monkeypatch.setattr("envex.env_wrapper.SecretsManager", FakeSecretsManager)
+
+    with pytest.raises(ValueError, match="secrets_manager"):
+        envex.Env(environ={}, secrets_manager=FakeSecretsManager(), url="https://vault")
 
 
 def test_is_set_uses_secret_manager_values():
@@ -368,14 +432,16 @@ def test_is_set_uses_secret_manager_values():
 def test_env_source_uses_canonical_variable_for_vault_precedence(monkeypatch):
     class FakeSecretsManager:
         def __init__(self, **_kwargs):
-            pass
+            self.client = object()
 
         def get_secret(self, key, default=None):
             return {"SECRET": "vault"}.get(key, default)
 
     monkeypatch.setattr("envex.env_wrapper.SecretsManager", FakeSecretsManager)
 
-    env = envex.Env(environ={"ENVEX_SOURCE": "vault", "SECRET": "env"})
+    env = envex.Env(
+        environ={"ENVEX_SOURCE": "vault", "SECRET": "env", "VAULT_TOKEN": "token"}
+    )
 
     assert env.get("SECRET") == "vault"
 
@@ -384,14 +450,16 @@ def test_env_source_uses_canonical_variable_for_vault_precedence(monkeypatch):
 def test_env_source_normalizes_vault_precedence(source, monkeypatch):
     class FakeSecretsManager:
         def __init__(self, **_kwargs):
-            pass
+            self.client = object()
 
         def get_secret(self, key, default=None):
             return {"SECRET": "vault"}.get(key, default)
 
     monkeypatch.setattr("envex.env_wrapper.SecretsManager", FakeSecretsManager)
 
-    env = envex.Env(environ={"ENVEX_SOURCE": source, "SECRET": "env"})
+    env = envex.Env(
+        environ={"ENVEX_SOURCE": source, "SECRET": "env", "VAULT_TOKEN": "token"}
+    )
 
     assert env.get("SECRET") == "vault"
 


### PR DESCRIPTION
## Summary

- Add path-scoped `Env(secrets_manager=...)` views that reuse an authenticated Vault client without sharing path state.
- Isolate Vault cache entries by mount point and resolved logical path.
- Make Vault setup explicit: no usable configuration skips Vault, partial configuration warns and skips it, and complete configuration raises instead of silently falling back.
- Avoid redundant Vault-capable `Env` creation while `env2hvac` parses local dotenv inputs.

## Breaking change

Once complete Vault configuration resolves, authentication, network, TLS, permission, and sealed-Vault failures are raised rather than being treated as unavailable secrets.

## Validation

Formatting, linting, type analysis, diff validation, and focused Vault-manager tests passed. The full suite currently stalls in the unchanged crypto test `test_tampered_ciphertext_fails_authentication`; this was reproduced separately and is not in the UT-344 execution path.