### PR TITLE
UT-345: Avoid Vault lookups for cached secrets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - ⚠️ BREAKING CHANGE: Vault is now used only when a complete effective configuration resolves. Partial configuration emits a warning and is skipped; once configured, Vault authentication, network, TLS, permission, and sealed-state failures raise instead of silently falling back to local values.
 - `Env(secrets_manager=...)` now creates a path-scoped view that reuses an authenticated Vault client while retaining independent path selection.
 - Vault secret caches are now isolated by mount point and logical path, preventing cached values from one document being written to another.
+- Cached Vault secret reads no longer perform a token-authentication request; call `get_secrets()` to explicitly refresh a cached document.
 - `env2hvac` no longer creates an additional Vault-capable `Env` while parsing each local dotenv input.
 
 ### v5.0.0

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ The provided `envcrypt` utility conveniently allows conversion between encrypted
 Alternatively, `envex` provides seamless integration with HashiCorp Vault. This reduces the need to store plaintext secrets on the filesystem and provides a more secure approach for managing secrets.
 HashiCorp Vault functionality is optional. With no usable Vault configuration, envex uses local values only. Partial configuration is logged and skipped; once a complete Vault configuration resolves, Vault failures are raised rather than silently falling back to local values.
 Values fetched from Vault are cached by mounted logical path in the `SecretsManager` connection context. Derived managers created from the same manager reuse entries for the same path only.
-Envex does not automatically expire this cache or invalidate it when values are changed outside the instance; call `get_secrets()` to refresh values from Vault.
+Envex does not automatically expire this cache or invalidate it when values are changed outside the instance. A loaded document, including absent keys, is served without another Vault request; call `get_secrets()` to refresh it from Vault.
 
 #### Extended variables
 `envex` provides many features not available in other dotenv handlers (python-dotenv, etc.) including recursive

--- a/envex/env_hvac.py
+++ b/envex/env_hvac.py
@@ -211,6 +211,16 @@ class SecretsManager:
         self._cache[self._cache_key(path)] = cached
         return cached
 
+    @staticmethod
+    def _response_values(response: Any) -> dict | None:
+        if not isinstance(response, dict):
+            return None
+        data = response.get("data")
+        if not isinstance(data, dict):
+            return None
+        values = data.get("data")
+        return dict(values) if isinstance(values, dict) else None
+
     def _clear_cached(self, path: str = "") -> None:
         self._cache.pop(self._cache_key(path), None)
 
@@ -255,8 +265,9 @@ class SecretsManager:
                 if not _is_invalid_path(exc):
                     raise
                 return dict(self._replace_cached(path, {}))
-            values = response["data"].get("data", {}) if response else {}
-            return dict(self._replace_cached(path, values))
+            values = self._response_values(response)
+            if values is not None:
+                return dict(self._replace_cached(path, values))
         return dict(self._cache_entry(path) or {})
 
     def set_secrets(self, path: str = "", values: dict | None = None):

--- a/envex/env_hvac.py
+++ b/envex/env_hvac.py
@@ -203,6 +203,9 @@ class SecretsManager:
     def _cached(self, path: str = "") -> dict:
         return self._cache.setdefault(self._cache_key(path), {})
 
+    def _cache_entry(self, path: str = "") -> dict | None:
+        return self._cache.get(self._cache_key(path))
+
     def _replace_cached(self, path: str, values: dict) -> dict:
         cached = dict(values)
         self._cache[self._cache_key(path)] = cached
@@ -214,7 +217,7 @@ class SecretsManager:
     @property
     def _secrets(self) -> dict:
         """Compatibility alias for the manager's default-path cache entry."""
-        return self._cached()
+        return self._cache_entry() or {}
 
     @_secrets.setter
     def _secrets(self, values: dict) -> None:
@@ -252,9 +255,9 @@ class SecretsManager:
                 if not _is_invalid_path(exc):
                     raise
                 return dict(self._replace_cached(path, {}))
-            if response is not None and "data" in response:
-                return dict(self._replace_cached(path, response["data"].get("data", {})))
-        return dict(self._cached(path))
+            values = response["data"].get("data", {}) if response else {}
+            return dict(self._replace_cached(path, values))
+        return dict(self._cache_entry(path) or {})
 
     def set_secrets(self, path: str = "", values: dict | None = None):
         kv2 = self.kv2
@@ -279,14 +282,12 @@ class SecretsManager:
         self._clear_cached(path)
 
     def get_secret(self, key: str, default: str | None = None, error: bool = False):
-        if self.client:
-            # Check if the secret is already in the cache
-            secrets = self._cached()
-            if not secrets:
-                self.get_secrets()
-                secrets = self._cached()
-            if key in secrets:
-                return secrets[key]
+        secrets = self._cache_entry()
+        if secrets is None:
+            self.get_secrets()
+            secrets = self._cache_entry()
+        if secrets is not None and key in secrets:
+            return secrets[key]
         if error and default is None:
             raise KeyError(key)
         # Placeholder or None value when hvac is not available or secret not found

--- a/tests/test_env_hvac.py
+++ b/tests/test_env_hvac.py
@@ -337,7 +337,7 @@ def test_get_secrets_explicitly_refreshes_the_cached_document():
 
 
 def test_cached_empty_document_does_not_trigger_repeat_requests():
-    kv2 = FakeKvV2()
+    kv2 = FakeKvV2({("secret", ""): {}})
     manager = make_manager(kv2=kv2)
 
     assert manager.get_secret("MISSING") is None
@@ -379,6 +379,30 @@ def test_failed_refresh_preserves_the_last_successful_cache_entry():
         manager.get_secrets()
 
     assert manager.get_secret("KEY") == "cached"
+
+
+@pytest.mark.parametrize("response", [None, {}, {"data": None}, {"data": {}}])
+def test_ambiguous_refresh_preserves_the_last_successful_cache_entry(response):
+    class AmbiguousKvV2(FakeKvV2):
+        def read_secret_version(self, *args, **kwargs):
+            return response
+
+    manager = make_manager(kv2=AmbiguousKvV2())
+    manager._secrets = {"KEY": "cached"}
+
+    assert manager.get_secrets() == {"KEY": "cached"}
+    assert manager.get_secret("KEY") == "cached"
+
+
+def test_ambiguous_initial_response_does_not_create_a_cache_entry():
+    class AmbiguousKvV2(FakeKvV2):
+        def read_secret_version(self, *args, **kwargs):
+            return {"data": None}
+
+    manager = make_manager(kv2=AmbiguousKvV2())
+
+    assert manager.get_secrets() == {}
+    assert manager._cache == {}
 
 
 def test_secret_snapshots_do_not_expose_the_internal_cache():

--- a/tests/test_env_hvac.py
+++ b/tests/test_env_hvac.py
@@ -51,11 +51,13 @@ class FakeKvV2:
 class FakeClient:
     def __init__(self, kv2=None, mounts=None, authenticated=True):
         self.authenticated = authenticated
+        self.authentication_calls = 0
         self.seal_status = {"sealed": False}
         self.secrets = SimpleNamespace(kv=SimpleNamespace(v2=kv2 or FakeKvV2()))
         self._mounts = mounts or {"secret/": {"type": "kv"}}
 
     def is_authenticated(self):
+        self.authentication_calls += 1
         return self.authenticated
 
     @property
@@ -82,7 +84,7 @@ def make_manager(base_path="", mount_point="secret", kv2=None):
     manager._engine = None
     manager._mount_point = mount_point
     manager._base_path = SecretsManager.join(base_path)
-    manager._secrets = {}
+    manager._cache = {}
     return manager
 
 
@@ -305,6 +307,78 @@ def test_get_secrets_uses_kv_v2_read_with_mount_and_logical_path():
             "kwargs": {"raise_on_deleted_version": True},
         }
     ]
+
+
+def test_get_secret_uses_cached_document_without_reauthenticating():
+    kv2 = FakeKvV2({("secret", "base"): {"KEY": "original"}})
+    manager = make_manager(base_path="base", kv2=kv2)
+
+    assert manager.get_secret("KEY") == "original"
+    assert manager._client.authentication_calls == 1
+    assert len(kv2.read_calls) == 1
+
+    assert manager.get_secret("KEY") == "original"
+    assert manager.get_secret("MISSING", default="fallback") == "fallback"
+    assert manager._client.authentication_calls == 1
+    assert len(kv2.read_calls) == 1
+
+
+def test_get_secrets_explicitly_refreshes_the_cached_document():
+    kv2 = FakeKvV2({("secret", "base"): {"KEY": "original"}})
+    manager = make_manager(base_path="base", kv2=kv2)
+
+    assert manager.get_secret("KEY") == "original"
+    kv2.store[("secret", "base")] = {"KEY": "refreshed"}
+
+    assert manager.get_secrets() == {"KEY": "refreshed"}
+    assert manager.get_secret("KEY") == "refreshed"
+    assert manager._client.authentication_calls == 2
+    assert len(kv2.read_calls) == 2
+
+
+def test_cached_empty_document_does_not_trigger_repeat_requests():
+    kv2 = FakeKvV2()
+    manager = make_manager(kv2=kv2)
+
+    assert manager.get_secret("MISSING") is None
+    assert manager.get_secret("MISSING") is None
+    assert manager._client.authentication_calls == 1
+    assert len(kv2.read_calls) == 1
+
+
+def test_inspecting_secrets_does_not_create_a_cache_entry():
+    kv2 = FakeKvV2({("secret", "base"): {"KEY": "value"}})
+    manager = make_manager(base_path="base", kv2=kv2)
+
+    assert manager.secrets == {}
+    assert manager.get_secret("KEY") == "value"
+    assert manager._client.authentication_calls == 1
+
+
+def test_unavailable_client_does_not_create_an_empty_cache_entry():
+    kv2 = FakeKvV2({("secret", "base"): {"KEY": "value"}})
+    manager = make_manager(base_path="base", kv2=kv2)
+    manager._client.authenticated = False
+
+    assert manager.get_secret("KEY") is None
+    assert manager._cache == {}
+
+    manager._client.authenticated = True
+    assert manager.get_secret("KEY") == "value"
+
+
+def test_failed_refresh_preserves_the_last_successful_cache_entry():
+    class FailingKvV2(FakeKvV2):
+        def read_secret_version(self, *args, **kwargs):
+            raise RuntimeError("connection lost")
+
+    manager = make_manager(kv2=FailingKvV2())
+    manager._secrets = {"KEY": "cached"}
+
+    with pytest.raises(RuntimeError, match="connection lost"):
+        manager.get_secrets()
+
+    assert manager.get_secret("KEY") == "cached"
 
 
 def test_secret_snapshots_do_not_expose_the_internal_cache():


### PR DESCRIPTION
## Summary

- Serve cached Vault documents, including cached absences, without a token-authentication or KV request.
- Keep `get_secrets()` as the explicit refresh path and preserve the last successful cache entry when refresh fails.
- Document the explicit-refresh cache contract and add regression coverage for request-free cache hits.

## Impact

Vault-backed lookups make HTTP requests only when the relevant document has not yet been cached or when the caller explicitly refreshes it.

Closes #125